### PR TITLE
Feedback コンポーネントの追加

### DIFF
--- a/src/renderer/components/feedback/alert.tsx
+++ b/src/renderer/components/feedback/alert.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+import { Alert, AlertTitle, type AlertColor } from '@mui/material'
+
+type Severity = AlertColor
+type Variant = 'filled' | 'outlined' | 'standard'
+
+interface Props {
+  icon?: boolean
+  severity: Severity
+  title?: string
+  variant?: Variant
+  children?: ReactNode
+}
+
+export default function TAlert({ icon, severity, title, variant, children }: Props) {
+  return (
+    <Alert severity={severity} variant={variant} icon={icon}>
+      {title && <AlertTitle>{title}</AlertTitle>}
+      {children}
+    </Alert>
+  )
+}

--- a/src/renderer/components/feedback/circular-progress.tsx
+++ b/src/renderer/components/feedback/circular-progress.tsx
@@ -1,0 +1,9 @@
+import CircularProgress from '@mui/material/CircularProgress'
+
+interface Props {
+  size: number
+}
+
+export default function TCircularProgress({ size }: Props) {
+  return <CircularProgress size={`${size}px`} />
+}

--- a/src/renderer/components/feedback/dialog.tsx
+++ b/src/renderer/components/feedback/dialog.tsx
@@ -1,0 +1,29 @@
+import { Dialog, DialogActions, DialogContent, type DialogProps, DialogTitle } from '@mui/material'
+import type { ReactNode } from 'react'
+
+interface Props {
+  open: boolean
+  title?: string
+  size?: DialogProps['maxWidth']
+  children: ReactNode
+  actions?: ReactNode
+  onSubmit?: () => void
+  onClose: () => void
+}
+
+export default function TDialog(props: Props) {
+  return (
+    <Dialog
+      open={props.open}
+      fullWidth
+      maxWidth={props.size}
+      onClose={props.onClose}
+      component={props.onSubmit ? 'form' : undefined}
+      onSubmit={props.onSubmit}
+    >
+      {props.title && <DialogTitle>{props.title}</DialogTitle>}
+      <DialogContent>{props.children}</DialogContent>
+      {props.actions && <DialogActions>{props.actions}</DialogActions>}
+    </Dialog>
+  )
+}

--- a/src/renderer/components/feedback/snackbar.tsx
+++ b/src/renderer/components/feedback/snackbar.tsx
@@ -1,0 +1,27 @@
+import { Alert, type AlertColor, Snackbar, type SnackbarCloseReason } from '@mui/material'
+import * as React from 'react'
+
+export type Severity = AlertColor
+
+interface Props {
+  open: boolean
+  message: string
+  severity: Severity
+  onClose: () => void
+}
+
+export default function TSnackbar({ open, message, severity, onClose }: Props) {
+  const handleClose = (_: React.SyntheticEvent | Event, reason: SnackbarCloseReason) => {
+    if (reason === 'clickaway') {
+      return
+    }
+    onClose()
+  }
+  return (
+    <Snackbar open={open} autoHideDuration={5000} onClose={handleClose}>
+      <Alert severity={severity} variant="filled" onClose={onClose}>
+        {message}
+      </Alert>
+    </Snackbar>
+  )
+}


### PR DESCRIPTION
# 概要

MUIベースのFeedbackコンポーネントを追加しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/5

## 詳細

### 追加したコンポーネント

- `TAlert` - アラート表示コンポーネント
  - severityによる色分け（success, info, warning, error）
  - タイトル付きアラート対応
  - アイコン表示のオン/オフ
  - outlined/filled バリアント対応
- `TCircularProgress` - 円形プログレス表示コンポーネント
  - サイズ指定可能
- `TDialog` - ダイアログ表示コンポーネント
  - タイトル、コンテンツ、アクションの3セクション構成
  - maxWidth設定可能
  - 開閉状態の制御
- `TSnackbar` - スナックバー（トースト通知）コンポーネント
  - メッセージ表示
  - severityによる色分け
  - 自動クローズ対応

### コンポーネントの特徴

- MUIコンポーネントをラップしたシンプルな実装
- Tellアプリケーション用のTプレフィックス命名規則
- 必要最小限のプロパティに絞った設計
- TypeScript型定義済み