### PR TITLE
Form コンポーネントとレイアウトコンポーネントの追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,13 @@
         "@electron-toolkit/utils": "^4.0.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@hookform/resolvers": "^5.2.2",
         "@mui/icons-material": "^7.3.5",
         "@mui/material": "^7.3.5",
         "better-sqlite3": "^12.4.6",
         "drizzle-orm": "^0.44.7",
-        "electron-updater": "^6.3.9"
+        "electron-updater": "^6.3.9",
+        "react-hook-form": "^7.66.1"
       },
       "devDependencies": {
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -2002,6 +2004,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2996,6 +3010,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -9855,6 +9875,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.66.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.1.tgz",
+      "integrity": "sha512-2KnjpgG2Rhbi+CIiIBQQ9Df6sMGH5ExNyFl4Hw9qO7pIqMBR8Bvu9RQyjl3JM4vehzCh9soiNUM/xYMswb2EiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^7.3.5",
     "@mui/material": "^7.3.5",
     "better-sqlite3": "^12.4.6",
     "drizzle-orm": "^0.44.7",
-    "electron-updater": "^6.3.9"
+    "electron-updater": "^6.3.9",
+    "react-hook-form": "^7.66.1"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/src/renderer/components/form/button.tsx
+++ b/src/renderer/components/form/button.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@mui/material'
+import { type ReactNode, useCallback } from 'react'
+import { type ThemeColor } from '@renderer/types/color'
+
+interface Props {
+  variant?: 'contained' | 'outlined' | 'text'
+  onClick?: () => void
+  loading?: boolean
+  width?: number
+  height?: number
+  color?: ThemeColor
+  fullWidth?: boolean
+  fullHeight?: boolean
+  type?: 'button' | 'submit' | 'reset'
+  href?: string
+  disabled?: boolean
+  children: ReactNode
+}
+
+export default function TButton({
+  variant,
+  onClick,
+  loading,
+  width,
+  height,
+  color,
+  fullWidth,
+  fullHeight,
+  type,
+  href,
+  disabled,
+  children
+}: Props) {
+  const handleClick = useCallback(() => {
+    if (onClick) {
+      onClick()
+    }
+    if (href) {
+      window.location.href = href
+    }
+  }, [onClick, href])
+
+  return (
+    <Button
+      variant={variant}
+      loading={loading}
+      onClick={handleClick}
+      color={color}
+      type={type}
+      disabled={disabled}
+      sx={{
+        ...(width && { width: width }),
+        ...(height && { height: height }),
+        ...(fullWidth && { width: '100%' }),
+        ...(fullHeight && { height: '100%' })
+      }}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/renderer/components/form/checkbox.tsx
+++ b/src/renderer/components/form/checkbox.tsx
@@ -1,0 +1,49 @@
+import Checkbox from '@mui/material/Checkbox'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import {
+  type Control,
+  Controller,
+  type FieldError,
+  type FieldPath,
+  type FieldValues
+} from 'react-hook-form'
+import { FormControl, FormHelperText } from '@mui/material'
+
+interface Props<T extends FieldValues> {
+  label?: string
+  name: FieldPath<T>
+  control: Control<T>
+  disabled?: boolean
+  error?: FieldError
+}
+
+export default function TCheckbox<T extends FieldValues>({
+  label,
+  name,
+  control,
+  disabled,
+  error
+}: Props<T>) {
+  return (
+    <FormControl error={error !== undefined}>
+      <FormControlLabel
+        control={
+          <Controller
+            name={name}
+            control={control}
+            render={({ field }) => (
+              <Checkbox
+                {...field}
+                checked={field.value}
+                disabled={disabled}
+                onChange={(e) => field.onChange(e.target.checked)}
+              />
+            )}
+          />
+        }
+        label={label ?? ''}
+      />
+      {error && <FormHelperText>{error.message}</FormHelperText>}
+    </FormControl>
+  )
+}

--- a/src/renderer/components/form/file-select-button.tsx
+++ b/src/renderer/components/form/file-select-button.tsx
@@ -1,0 +1,63 @@
+import { Button, styled } from '@mui/material'
+import { type ChangeEvent, type ReactNode, useCallback } from 'react'
+
+interface Props {
+  id: string
+  accepts: string[]
+  multiple?: boolean
+  disabled?: boolean
+  maxSize?: number
+  children: ReactNode
+  onSelect: (files: File[]) => void
+  onError?: () => void
+}
+
+const StyledInput = styled('input')({})
+
+export default function TFileSelectButton({
+  id,
+  accepts,
+  multiple = false,
+  disabled = false,
+  maxSize,
+  children,
+  onSelect,
+  onError
+}: Props) {
+  const handleSelect = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (event.target.files) {
+        const array: File[] = []
+        const list: FileList = event.target.files
+        for (let index = 0; index < list.length; index += 1) {
+          const file = list.item(index)
+          if (file) {
+            array.push(file)
+          }
+        }
+        onSelect(array)
+        event.target.value = ''
+      }
+    },
+    [onSelect]
+  )
+  return (
+    <label htmlFor={id}>
+      <StyledInput
+        sx={{ display: 'none' }}
+        accept={accepts.join(',')}
+        type="file"
+        id={id}
+        name="file-select-button"
+        multiple={multiple}
+        size={maxSize}
+        disabled={disabled}
+        onChange={handleSelect}
+        onError={onError}
+      />
+      <Button variant="contained" component="span" disabled={disabled}>
+        {children}
+      </Button>
+    </label>
+  )
+}

--- a/src/renderer/components/form/form-item.tsx
+++ b/src/renderer/components/form/form-item.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+import TText from '@renderer/components/display/text'
+import TChip from '@renderer/components/display/chip'
+import { TColumn, TRow } from '@renderer/components/layout/flex-box'
+
+interface Props {
+  label: string
+  optional?: boolean
+  children: ReactNode
+}
+
+export default function TFormItem(props: Props) {
+  return (
+    <TColumn gap={0.5}>
+      <TRow align={'baseline'} gap={0.5}>
+        <TText variant={'caption'}>{props.label}</TText>
+        {props.optional && <TChip label={'optional'} size={'small'} variant={'outlined'} />}
+      </TRow>
+      {props.children}
+    </TColumn>
+  )
+}

--- a/src/renderer/components/form/form.tsx
+++ b/src/renderer/components/form/form.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+  onSubmit: () => void
+}
+
+export default function TForm({ children, onSubmit }: Props) {
+  return <form onSubmit={onSubmit}>{children}</form>
+}

--- a/src/renderer/components/form/icon-button.tsx
+++ b/src/renderer/components/form/icon-button.tsx
@@ -1,0 +1,24 @@
+import { IconButton } from '@mui/material'
+import { type ReactNode, type MouseEvent } from 'react'
+import { type ThemeColor } from '@renderer/types/color'
+
+interface Props {
+  color?: ThemeColor
+  children: ReactNode
+  loading?: boolean
+  onClick?: (element: Element) => void
+}
+
+export default function TIconButton(props: Props) {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (props.onClick) {
+      props.onClick(event?.target as Element)
+    }
+  }
+
+  return (
+    <IconButton color={props.color} onClick={handleClick} loading={props.loading}>
+      {props.children}
+    </IconButton>
+  )
+}

--- a/src/renderer/components/form/radio-group.tsx
+++ b/src/renderer/components/form/radio-group.tsx
@@ -1,0 +1,70 @@
+import RadioGroup from '@mui/material/RadioGroup'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import {
+  type Control,
+  Controller,
+  type FieldError,
+  type FieldPath,
+  type FieldValues
+} from 'react-hook-form'
+import type { ReactNode } from 'react'
+import { FormControl, FormHelperText, Radio } from '@mui/material'
+
+interface RadioItem {
+  value: number
+  label: ReactNode
+}
+
+interface Props<T extends FieldValues> {
+  items: RadioItem[]
+  row?: boolean
+  name: FieldPath<T>
+  fontSize?: number
+  control: Control<T>
+  disabled?: boolean
+  error?: FieldError
+}
+
+export default function TRadioGroup<T extends FieldValues>({
+  items,
+  row = false,
+  name,
+  fontSize,
+  control,
+  disabled,
+  error
+}: Props<T>) {
+  return (
+    <Controller<T>
+      name={name}
+      control={control}
+      render={({ field }) => (
+        <FormControl error={error !== undefined}>
+          <RadioGroup row={row} {...field} value={field.value ?? ''}>
+            {items.map((item) => (
+              <FormControlLabel
+                key={item.value}
+                control={
+                  <Radio
+                    sx={{
+                      '& .MuiSvgIcon-root': {
+                        fontSize
+                      }
+                    }}
+                  />
+                }
+                value={item.value}
+                label={item.label}
+                disabled={disabled}
+                sx={{
+                  fontSize
+                }}
+              />
+            ))}
+          </RadioGroup>
+          {error && <FormHelperText>{error.message}</FormHelperText>}
+        </FormControl>
+      )}
+    />
+  )
+}

--- a/src/renderer/components/form/select.tsx
+++ b/src/renderer/components/form/select.tsx
@@ -1,0 +1,53 @@
+import { FormControl, FormHelperText, MenuItem, Select } from '@mui/material'
+import { type ReactNode } from 'react'
+import {
+  type Control,
+  Controller,
+  type FieldError,
+  type FieldPath,
+  type FieldValues
+} from 'react-hook-form'
+
+interface Item {
+  value: string
+  label: ReactNode
+}
+
+interface Props<T extends FieldValues> {
+  items: Item[]
+  name: FieldPath<T>
+  control: Control<T>
+  error?: FieldError
+}
+
+export default function TSelect<T extends FieldValues>(props: Props<T>) {
+  return (
+    <Controller
+      name={props.name}
+      control={props.control}
+      render={({ field }) => (
+        <FormControl error={props.error !== undefined}>
+          <Select
+            variant={'outlined'}
+            size="small"
+            {...field}
+            value={field.value ?? ''}
+            onChange={(e) => {
+              field.onChange(e.target.value)
+            }}
+          >
+            <MenuItem value={''} disabled>
+              選択してください
+            </MenuItem>
+            {props.items.map((item) => (
+              <MenuItem key={item.value} value={item.value}>
+                {item.label}
+              </MenuItem>
+            ))}
+          </Select>
+          {props.error?.message && <FormHelperText>{props.error.message}</FormHelperText>}
+        </FormControl>
+      )}
+    />
+  )
+}

--- a/src/renderer/components/form/text-field.tsx
+++ b/src/renderer/components/form/text-field.tsx
@@ -1,0 +1,48 @@
+import { InputAdornment, TextField } from '@mui/material'
+import type { FieldError, UseFormRegisterReturn } from 'react-hook-form'
+import type { ReactNode } from 'react'
+
+interface Props {
+  type?: 'text' | 'password' | 'email' | 'date' | 'datetime' | 'number'
+  readonly?: boolean
+  fullWidth?: boolean
+  register: UseFormRegisterReturn
+  error?: FieldError
+  placeholder?: string
+  prefix?: ReactNode
+  suffix?: ReactNode
+  multiline?: boolean
+  rows?: number
+  disabled?: boolean
+}
+
+export default function TTextField(props: Props) {
+  return (
+    <TextField
+      variant="outlined"
+      size="small"
+      type={props.type}
+      slotProps={{
+        htmlInput: {
+          readOnly: props.readonly
+        },
+        input: {
+          startAdornment: props.prefix && (
+            <InputAdornment position="start">{props.prefix}</InputAdornment>
+          ),
+          endAdornment: props.suffix && (
+            <InputAdornment position="end">{props.suffix}</InputAdornment>
+          )
+        }
+      }}
+      fullWidth={props.fullWidth}
+      placeholder={props.placeholder}
+      multiline={props.multiline}
+      rows={props.rows}
+      error={props.error !== undefined}
+      helperText={props.error?.message}
+      disabled={props.disabled}
+      {...props.register}
+    />
+  )
+}

--- a/src/renderer/components/layout/flex-box.tsx
+++ b/src/renderer/components/layout/flex-box.tsx
@@ -1,0 +1,122 @@
+import { Box } from '@mui/material'
+import React from 'react'
+
+interface Props {
+  direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse'
+  justify?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly'
+  align?: 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline'
+  alignContent?:
+    | 'flex-start'
+    | 'center'
+    | 'flex-end'
+    | 'space-between'
+    | 'space-around'
+    | 'space-evenly'
+    | 'stretch'
+  wrap?: 'nowrap' | 'wrap' | 'wrap-reverse'
+  gap?: number | string
+  rowGap?: number | string
+  columnGap?: number | string
+  grow?: number
+  shrink?: number
+  basis?: number | string
+  flex?: string | number
+  overflow?: 'hidden' | 'visible' | 'scroll' | 'auto'
+  width?: number | string
+  fullWidth?: boolean
+  height?: number | string
+  fullHeight?: boolean
+  ma?: number
+  mx?: number
+  ml?: number
+  mr?: number
+  my?: number
+  mt?: number
+  mb?: number
+  pa?: number
+  px?: number
+  py?: number
+  pl?: number
+  pr?: number
+  pt?: number
+  pb?: number
+  children: React.ReactNode
+}
+
+export default function TFlexBox({
+  direction = 'row',
+  justify = 'flex-start',
+  align = 'stretch',
+  alignContent,
+  wrap = 'nowrap',
+  gap,
+  rowGap,
+  columnGap,
+  grow,
+  shrink,
+  basis,
+  flex,
+  overflow,
+  width,
+  fullWidth,
+  height,
+  fullHeight,
+  ma,
+  mx = ma,
+  my = ma,
+  mt = my,
+  mb = my,
+  ml = mx,
+  mr = mx,
+  pa,
+  px = pa,
+  py = pa,
+  pt = py,
+  pb = py,
+  pl = px,
+  pr = px,
+  children
+}: Props) {
+  const flexStyles = {
+    display: 'flex',
+    flexDirection: direction,
+    justifyContent: justify,
+    alignItems: align,
+    ...(alignContent && { alignContent }),
+    flexWrap: wrap,
+    ...(gap !== undefined && { gap }),
+    ...(rowGap !== undefined && { rowGap }),
+    ...(columnGap !== undefined && { columnGap }),
+    ...(grow !== undefined && { flexGrow: grow }),
+    ...(shrink !== undefined && { flexShrink: shrink }),
+    ...(basis !== undefined && { flexBasis: basis }),
+    ...(flex !== undefined && { flex }),
+    ...(overflow !== undefined && { overflow }),
+    ...(width !== undefined && { width }),
+    ...(fullWidth && { width: '100%' }),
+    ...(height !== undefined && { height }),
+    ...(fullHeight && { height: '100%' }),
+    mt,
+    mb,
+    ml,
+    mr,
+    pt,
+    pb,
+    pl,
+    pr
+  }
+
+  return <Box sx={{ ...flexStyles }}>{children}</Box>
+}
+
+export function TRow(props: Omit<Props, 'direction'>) {
+  return <TFlexBox direction="row" {...props} />
+}
+
+export function TColumn(props: Omit<Props, 'direction'>) {
+  return <TFlexBox direction="column" {...props} />
+}
+
+export function TCenter(props: Omit<Props, 'justify' | 'align'>) {
+  return <TFlexBox justify="center" align="center" {...props} />
+}


### PR DESCRIPTION
# 概要

MUIベースのFormコンポーネントとLayoutコンポーネントを追加し、react-hook-formを導入しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/6

## 詳細

### 追加したパッケージ

- `react-hook-form` - フォーム管理ライブラリ
- `@hookform/resolvers` - バリデーションリゾルバー

### 追加したFormコンポーネント

- `TButton` - ボタンコンポーネント
  - variant（contained/outlined/text）対応
  - ローディング状態表示
  - サイズ、色指定可能
  - href指定でリンクとしても使用可能
- `TCheckbox` - チェックボックスコンポーネント
  - ラベル付き
  - チェック状態管理
- `TFileSelectButton` - ファイル選択ボタンコンポーネント
  - 複数ファイル選択対応
  - accept属性でファイルタイプ制限可能
- `TFormItem` - フォームアイテムラッパーコンポーネント
  - ラベル、必須マーク表示
  - エラーメッセージ表示
- `TForm` - フォームコンポーネント
  - submit処理対応
- `TIconButton` - アイコンボタンコンポーネント
  - サイズ、色指定可能
- `TRadioGroup` - ラジオグループコンポーネント
  - 複数選択肢の管理
  - ラベル付き
- `TSelect` - セレクトボックスコンポーネント
  - 選択肢の管理
  - ラベル付き
- `TTextField` - テキストフィールドコンポーネント
  - 複数行対応
  - タイプ指定（text/password等）
  - placeholder、ヘルパーテキスト対応

### 追加したLayoutコンポーネント

- `TFlexBox` - Flexboxレイアウトコンポーネント
  - direction（row/column）指定
  - justifyContent、alignItems設定
  - gap、padding、margin設定
  - ラップ対応
  - サイズ指定可能

### コンポーネントの特徴

- MUIコンポーネントをラップしたシンプルな実装
- Tellアプリケーション用のTプレフィックス命名規則
- react-hook-formとの統合を想定した設計
- パスエイリアス（@renderer）を使用した絶対パスインポート
- TypeScript型定義済み