### PR TITLE
Layout コンポーネントの追加

### DIFF
--- a/src/renderer/components/layout/absolute-box.tsx
+++ b/src/renderer/components/layout/absolute-box.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/material'
+import type { ReactNode } from 'react'
+
+interface Props {
+  top?: string | number
+  left?: string | number
+  right?: string | number
+  bottom?: string | number
+  hidden?: boolean
+  children: ReactNode
+}
+
+export default function TAbsoluteBox({ top, left, right, bottom, hidden, children }: Props) {
+  return (
+    <Box
+      top={top}
+      left={left}
+      right={right}
+      bottom={bottom}
+      position="absolute"
+      boxSizing="border-box"
+      hidden={hidden}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/src/renderer/components/layout/fixed-box.tsx
+++ b/src/renderer/components/layout/fixed-box.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+import { Box } from '@mui/material'
+
+interface Props {
+  top?: string | number
+  left?: string | number
+  right?: string | number
+  bottom?: string | number
+  zIndex?: number
+  children: ReactNode
+}
+
+export default function TFixedBox({ top, left, right, bottom, zIndex, children }: Props) {
+  return (
+    <Box
+      top={top}
+      left={left}
+      right={right}
+      bottom={bottom}
+      position="fixed"
+      boxSizing="border-box"
+      zIndex={zIndex}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/src/renderer/components/layout/grid-item.tsx
+++ b/src/renderer/components/layout/grid-item.tsx
@@ -1,0 +1,32 @@
+import { Box } from '@mui/material'
+import { type ReactNode } from 'react'
+
+interface Area {
+  top: number
+  left: number
+  bottom: number
+  right: number
+}
+
+interface Props {
+  align?: 'start' | 'end' | 'center' | 'stretch'
+  justify?: 'start' | 'end' | 'center' | 'stretch'
+  area?: Area
+  children: ReactNode
+}
+
+export default function TGridItem(props: Props) {
+  const area = props.area
+  const gridArea = area ? `${area.top} / ${area.left} / ${area.bottom} / ${area.right}` : undefined
+  return (
+    <Box
+      sx={{
+        alignSelf: props.align,
+        justifySelf: props.justify,
+        gridArea
+      }}
+    >
+      {props.children}
+    </Box>
+  )
+}

--- a/src/renderer/components/layout/grid.tsx
+++ b/src/renderer/components/layout/grid.tsx
@@ -1,0 +1,50 @@
+import { Box } from '@mui/material'
+import React from 'react'
+
+interface Props {
+  columns?: string[]
+  rows?: string[]
+  gap?: number
+  rowGap?: number
+  columnGap?: number
+  justifyItems?: 'start' | 'end' | 'center' | 'stretch'
+  alignItems?: 'start' | 'end' | 'center' | 'stretch'
+  justifyContent?:
+    | 'start'
+    | 'end'
+    | 'center'
+    | 'stretch'
+    | 'space-around'
+    | 'space-between'
+    | 'space-evenly'
+  alignContent?:
+    | 'start'
+    | 'end'
+    | 'center'
+    | 'stretch'
+    | 'space-around'
+    | 'space-between'
+    | 'space-evenly'
+  children: React.ReactNode
+}
+
+export default function TGrid(props: Props) {
+  const gridStyles = {
+    display: 'grid',
+    ...(props.columns && {
+      gridTemplateColumns: props.columns.join(' ')
+    }),
+    ...(props.rows && {
+      gridTemplateRows: props.rows.join(' ')
+    }),
+    ...(props.gap !== undefined && { gap: props.gap }),
+    ...(props.rowGap !== undefined && { rowGap: props.rowGap }),
+    ...(props.columnGap !== undefined && { columnGap: props.columnGap }),
+    ...(props.justifyItems && { justifyItems: props.justifyItems }),
+    ...(props.alignItems && { alignItems: props.alignItems }),
+    ...(props.justifyContent && { justifyContent: props.justifyContent }),
+    ...(props.alignContent && { alignContent: props.alignContent })
+  }
+
+  return <Box sx={{ ...gridStyles }}>{props.children}</Box>
+}

--- a/src/renderer/components/layout/relative-box.tsx
+++ b/src/renderer/components/layout/relative-box.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+import { Box } from '@mui/material'
+
+interface Props {
+  width?: string
+  height?: string
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+  children: ReactNode
+}
+
+export default function TRelativeBox({
+  width = '100%',
+  height = '100%',
+  onMouseEnter,
+  onMouseLeave,
+  children
+}: Props) {
+  return (
+    <Box
+      width={width}
+      height={height}
+      position="relative"
+      boxSizing="border-box"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      {children}
+    </Box>
+  )
+}


### PR DESCRIPTION
# 概要

MUIベースのLayoutコンポーネントを追加しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/7

## 詳細

### 追加したLayoutコンポーネント

- `TAbsoluteBox` - 絶対位置配置コンポーネント
  - top, left, right, bottom で位置指定
  - hidden プロパティで表示/非表示制御
  - 絶対配置が必要な要素に使用
- `TFixedBox` - 固定位置配置コンポーネント
  - top, left, right, bottom で位置指定
  - zIndex で重なり順を制御
  - ヘッダーやフッターなどの固定要素に使用
- `TRelativeBox` - 相対位置配置コンポーネント
  - width, height で幅と高さを指定
  - onMouseEnter, onMouseLeave イベント対応
  - 相対配置が必要な親要素として使用
- `TGrid` - グリッドレイアウトコンポーネント
  - columns, rows でグリッド定義
  - gap, rowGap, columnGap で間隔設定
  - justifyItems, alignItems, justifyContent, alignContent で配置制御
  - 複雑なレイアウトに対応
- `TGridItem` - グリッドアイテムコンポーネント
  - area で配置領域を指定（top/left/bottom/right）
  - align, justify で個別の配置制御
  - TGridコンポーネントの子要素として使用

### コンポーネントの特徴

- MUI Boxコンポーネントをベースにした実装
- Tellアプリケーション用のTプレフィックス命名規則
- CSS Grid と 位置指定（absolute/fixed/relative）をサポート
- TypeScript型定義済み
- シンプルで直感的なAPI設計