### PR TITLE
Surface コンポーネントの追加

### DIFF
--- a/src/renderer/components/surface/accordion.tsx
+++ b/src/renderer/components/surface/accordion.tsx
@@ -1,0 +1,18 @@
+import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material'
+import type { ReactNode } from 'react'
+
+interface Props {
+  title: string
+  children: ReactNode
+}
+
+export default function TAccordion(props: Props) {
+  return (
+    <Accordion>
+      <AccordionSummary>
+        <Typography>{props.title}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>{props.children}</AccordionDetails>
+    </Accordion>
+  )
+}

--- a/src/renderer/components/surface/app-bar.tsx
+++ b/src/renderer/components/surface/app-bar.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+import { AppBar, Toolbar } from '@mui/material'
+import type { ThemeColor } from '@renderer/types/color'
+
+interface Props {
+  color?: ThemeColor
+  position?: 'fixed' | 'static'
+  children: ReactNode
+}
+
+export default function TAppBar({ color = 'secondary', position = 'fixed', children }: Props) {
+  return (
+    <AppBar position={position} elevation={1} color={color}>
+      <Toolbar variant="dense" disableGutters>
+        {children}
+      </Toolbar>
+    </AppBar>
+  )
+}

--- a/src/renderer/components/surface/card.tsx
+++ b/src/renderer/components/surface/card.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react'
+import { Card, CardActionArea, CardActions, CardContent, CardHeader } from '@mui/material'
+
+interface Props {
+  header?: ReactNode
+  children: ReactNode
+  actions?: ReactNode
+  onClick?: () => void
+  onClickHeader?: () => void
+}
+
+function TCardHeader(props: { children: ReactNode; onClick?: () => void }) {
+  const { children, onClick } = props
+  if (onClick) {
+    return (
+      <CardActionArea onClick={onClick}>
+        <CardHeader title={children} />
+      </CardActionArea>
+    )
+  }
+  return <CardHeader title={children} />
+}
+
+function TCardContent(props: { children: ReactNode; onClick?: () => void }) {
+  const { children, onClick } = props
+  if (onClick) {
+    return (
+      <CardActionArea onClick={onClick}>
+        <CardContent>{children}</CardContent>
+      </CardActionArea>
+    )
+  }
+  return <CardContent>{children}</CardContent>
+}
+
+export default function TCard({ header, children, actions, onClick, onClickHeader }: Props) {
+  return (
+    <Card
+      variant={'outlined'}
+      sx={{
+        width: '100%',
+        borderRadius: 4
+      }}
+    >
+      {header && <TCardHeader onClick={onClickHeader}>{header}</TCardHeader>}
+      <TCardContent onClick={onClick}>{children}</TCardContent>
+      {actions && <CardActions>{actions}</CardActions>}
+    </Card>
+  )
+}


### PR DESCRIPTION
# 概要

MUIベースのSurfaceコンポーネントを追加しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/9

## 詳細

### 追加したSurfaceコンポーネント

- `TAccordion` - アコーディオンコンポーネント
  - 折りたたみ可能なパネル
  - タイトルとコンテンツで構成
  - 詳細情報の表示/非表示を切り替え
- `TAppBar` - アプリケーションバーコンポーネント
  - アプリケーション上部に固定表示
  - color プロパティでテーマカラーを指定
  - position プロパティで配置タイプを指定（fixed/static等）
  - Toolbarを内包
- `TCard` - カードコンポーネント
  - ヘッダー、コンテンツ、アクションの3セクション構成
  - ヘッダーとコンテンツにクリックイベント設定可能
  - outlinedバリアント
  - 角丸デザイン

### リファクタリング内容

- コンポーネント名をMプレフィックスからTプレフィックスに変更
- Cardコンポーネントからcolor関連プロパティを削除（MUIデフォルトを使用）
- パスエイリアスを絶対パスに修正（@/types → @renderer/types）
- 不要なインポートを整理
- コードフォーマットの統一

### コンポーネントの特徴

- MUIコンポーネントをラップしたシンプルな実装
- Tellアプリケーション用のTプレフィックス命名規則
- コンテンツを表示するための基本的なサーフェスコンポーネントを提供
- TypeScript型定義済み