### PR TITLE
サイドバーナビゲーション機能の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "better-sqlite3": "^12.4.6",
         "drizzle-orm": "^0.44.7",
         "electron-updater": "^6.3.9",
-        "react-hook-form": "^7.66.1"
+        "react-hook-form": "^7.66.1",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -10456,6 +10457,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "better-sqlite3": "^12.4.6",
     "drizzle-orm": "^0.44.7",
     "electron-updater": "^6.3.9",
-    "react-hook-form": "^7.66.1"
+    "react-hook-form": "^7.66.1",
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/src/renderer/components/display/icons/home.tsx
+++ b/src/renderer/components/display/icons/home.tsx
@@ -1,0 +1,5 @@
+import { IoHomeOutline } from 'react-icons/io5'
+
+export default function HomeIcon() {
+  return <IoHomeOutline />
+}

--- a/src/renderer/components/display/icons/settings.tsx
+++ b/src/renderer/components/display/icons/settings.tsx
@@ -1,0 +1,5 @@
+import { IoSettingsOutline } from 'react-icons/io5'
+
+export default function SettingsIcon() {
+  return <IoSettingsOutline />
+}

--- a/src/renderer/components/display/list.tsx
+++ b/src/renderer/components/display/list.tsx
@@ -1,4 +1,5 @@
 import { List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material'
+import { Link } from '@tanstack/react-router'
 import type { ReactNode } from 'react'
 
 interface Item {
@@ -7,6 +8,7 @@ interface Item {
   icon?: ReactNode
   selected?: boolean
   hide?: boolean
+  href?: string
   onClick?: () => void
 }
 
@@ -19,10 +21,22 @@ function TListItem(props: { item: Item }) {
 
   if (item.onClick) {
     return (
-      <ListItemButton onClick={item.onClick} selected={item.selected}>
-        {item.icon && <ListItemIcon>{item.icon}</ListItemIcon>}
-        <ListItemText primary={item.text} />
-      </ListItemButton>
+      <ListItem disablePadding>
+        <ListItemButton onClick={item.onClick} selected={item.selected}>
+          {item.icon && <ListItemIcon>{item.icon}</ListItemIcon>}
+          <ListItemText primary={item.text} />
+        </ListItemButton>
+      </ListItem>
+    )
+  }
+  if (item.href) {
+    return (
+      <ListItem disablePadding>
+        <ListItemButton to={item.href} selected={item.selected} component={Link}>
+          {item.icon && <ListItemIcon>{item.icon}</ListItemIcon>}
+          <ListItemText primary={item.text} />
+        </ListItemButton>
+      </ListItem>
     )
   }
   return (

--- a/src/renderer/features/system/side-bar.tsx
+++ b/src/renderer/features/system/side-bar.tsx
@@ -1,0 +1,32 @@
+import TDrawer from '@renderer/components/navigation/drawer'
+import TList from '@renderer/components/display/list'
+import HomeIcon from '@renderer/components/display/icons/home'
+import SettingsIcon from '@renderer/components/display/icons/settings'
+import { useMatchRoute } from '@tanstack/react-router'
+
+export default function SideBar() {
+  const matchRoute = useMatchRoute()
+
+  return (
+    <TDrawer open={true} variant={'permanent'}>
+      <TList
+        items={[
+          {
+            id: 'home',
+            text: 'Home',
+            icon: <HomeIcon />,
+            selected: matchRoute({ to: '/', fuzzy: true }) as boolean,
+            href: '/'
+          },
+          {
+            id: 'setting',
+            text: 'Setting',
+            icon: <SettingsIcon />,
+            selected: matchRoute({ to: '/settings', fuzzy: true }) as boolean,
+            href: '/settings'
+          }
+        ]}
+      />
+    </TDrawer>
+  )
+}

--- a/src/renderer/routeTree.gen.ts
+++ b/src/renderer/routeTree.gen.ts
@@ -9,8 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as IndexRouteImport } from './routes/index'
 
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +25,39 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/settings'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/settings'
+  id: '__root__' | '/' | '/settings'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SettingsRoute: typeof SettingsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +70,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SettingsRoute: SettingsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/renderer/routes/__root.tsx
+++ b/src/renderer/routes/__root.tsx
@@ -1,9 +1,11 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
+import SideBar from '@renderer/features/system/side-bar'
 
 export const Route = createRootRoute({
   component: () => (
     <>
+      <SideBar />
       <Outlet />
       <TanStackRouterDevtools />
     </>

--- a/src/renderer/routes/settings.tsx
+++ b/src/renderer/routes/settings.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/settings')({
+  component: RouteComponent
+})
+
+function RouteComponent() {
+  return <div>/settings</div>
+}


### PR DESCRIPTION
# 概要

アプリケーションの左側に常時表示されるサイドバーナビゲーションを実装しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/10

## 詳細

### 追加機能
- react-icons (v5.5.0) を導入し、アイコンコンポーネントを実装
  - ホームアイコンコンポーネント (`src/renderer/components/display/icons/home.tsx`)
  - 設定アイコンコンポーネント (`src/renderer/components/display/icons/settings.tsx`)
- サイドバーコンポーネント (`src/renderer/features/system/side-bar.tsx`) を実装
  - TanStack Routerと統合し、現在のルートに応じて選択状態を表示
  - ホームと設定ページへのナビゲーションリンクを配置
- 設定ページルート (`src/renderer/routes/settings.tsx`) を追加

### 変更内容
- `TList` コンポーネントに `href` プロパティを追加し、TanStack Router の `Link` コンポーネントと統合
- ルートレイアウト (`__root.tsx`) にサイドバーを配置

### 技術詳細
- Material-UIの `Drawer` コンポーネントを永続表示モードで使用
- TanStack Routerの `useMatchRoute` フックで現在のルートを判定
- パス別名 (`@renderer/*`) を使用したクリーンなインポート構造を維持