### PR TITLE
登録済みGitHubアカウント一覧表示機能の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@mui/material": "^7.3.5",
         "@tanstack/react-router": "^1.131.50",
         "better-sqlite3": "^12.4.6",
+        "dayjs": "^1.11.19",
         "drizzle-orm": "^0.44.7",
         "electron-updater": "^6.3.9",
         "react-hook-form": "^7.66.1",
@@ -5831,6 +5832,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@mui/material": "^7.3.5",
     "@tanstack/react-router": "^1.131.50",
     "better-sqlite3": "^12.4.6",
+    "dayjs": "^1.11.19",
     "drizzle-orm": "^0.44.7",
     "electron-updater": "^6.3.9",
     "react-hook-form": "^7.66.1",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '@resources/icon.png?asset'
 import { githubService } from '@main/services/github-service'
+import { githubAccountRepository } from '@main/repositories/github/account-repository'
 
 function createWindow(): void {
   // Create the browser window.
@@ -58,6 +59,17 @@ app.whenReady().then(() => {
     try {
       const account = await githubService.createAccount(personalAccessToken)
       return { success: true, data: account }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred'
+      }
+    }
+  })
+  ipcMain.handle('github:getAccounts', async () => {
+    try {
+      const accounts = await githubAccountRepository.findAll()
+      return { success: true, data: accounts }
     } catch (error) {
       return {
         success: false,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -7,6 +7,11 @@ interface GitHubAPI {
     data?: GithubAccount
     error?: string
   }>
+  getAccounts: () => Promise<{
+    success: boolean
+    data?: GithubAccount[]
+    error?: string
+  }>
 }
 
 interface API {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,7 +5,8 @@ import { electronAPI } from '@electron-toolkit/preload'
 const api = {
   github: {
     createAccount: (personalAccessToken: string) =>
-      ipcRenderer.invoke('github:createAccount', personalAccessToken)
+      ipcRenderer.invoke('github:createAccount', personalAccessToken),
+    getAccounts: () => ipcRenderer.invoke('github:getAccounts')
   }
 }
 

--- a/src/renderer/components/display/list.tsx
+++ b/src/renderer/components/display/list.tsx
@@ -22,7 +22,7 @@ function TListItem(props: { item: Item }) {
   if (item.onClick) {
     return (
       <ListItem disablePadding>
-        <ListItemButton onClick={item.onClick} selected={item.selected}>
+        <ListItemButton onClick={item.onClick} selected={!!item.selected}>
           {item.icon && <ListItemIcon>{item.icon}</ListItemIcon>}
           <ListItemText primary={item.text} />
         </ListItemButton>
@@ -32,7 +32,7 @@ function TListItem(props: { item: Item }) {
   if (item.href) {
     return (
       <ListItem disablePadding>
-        <ListItemButton to={item.href} selected={item.selected} component={Link}>
+        <ListItemButton to={item.href} selected={!!item.selected} component={Link}>
           {item.icon && <ListItemIcon>{item.icon}</ListItemIcon>}
           <ListItemText primary={item.text} />
         </ListItemButton>

--- a/src/renderer/features/settings/github/account-create-form.tsx
+++ b/src/renderer/features/settings/github/account-create-form.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { TColumn, TRow } from '@renderer/components/layout/flex-box'
+import TAlert from '@renderer/components/feedback/alert'
+import TForm from '@renderer/components/form/form'
+import TFormItem from '@renderer/components/form/form-item'
+import TTextField from '@renderer/components/form/text-field'
+import TButton from '@renderer/components/form/button'
+import useResolver from '@renderer/hooks/resolver'
+
+interface FormData {
+  token: string
+}
+
+export default function GitHubAccountCreateForm() {
+  const resolver = useResolver()
+  const [processing, setProcessing] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset
+  } = useForm<FormData>({
+    resolver: resolver.githubPersonalAccessTokenRegister
+  })
+
+  const onSubmit = async (data: FormData) => {
+    setProcessing(true)
+    setSuccessMessage(null)
+    setErrorMessage(null)
+
+    try {
+      const result = await window.api.github.createAccount(data.token)
+
+      if (result.success && result.data) {
+        setSuccessMessage(
+          `Successfully registered GitHub account: ${result.data.login} (${result.data.name || 'No name'})`
+        )
+        reset()
+      } else {
+        setErrorMessage(result.error || 'Failed to register GitHub account')
+      }
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'An unexpected error occurred')
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  return (
+    <TColumn gap={2} fullWidth>
+      {successMessage && <TAlert severity="success">{successMessage}</TAlert>}
+      {errorMessage && <TAlert severity="error">{errorMessage}</TAlert>}
+
+      <TForm onSubmit={handleSubmit(onSubmit)}>
+        <TFormItem label="Personal Access Token">
+          <TRow gap={2}>
+            <TTextField
+              type="password"
+              register={register('token')}
+              error={errors.token}
+              placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+              fullWidth
+              disabled={processing}
+            />
+            <TColumn>
+              <TButton type="submit" variant="contained" color="primary" processing={processing}>
+                Register
+              </TButton>
+            </TColumn>
+          </TRow>
+        </TFormItem>
+      </TForm>
+    </TColumn>
+  )
+}

--- a/src/renderer/features/settings/github/account-table.tsx
+++ b/src/renderer/features/settings/github/account-table.tsx
@@ -1,0 +1,53 @@
+import TGrid from '@renderer/components/layout/grid'
+import TAvatar from '@renderer/components/display/avatar'
+import TText from '@renderer/components/display/text'
+import TLink from '@renderer/components/navigation/link'
+import { TColumn } from '@renderer/components/layout/flex-box'
+import { useEffect, useState } from 'react'
+import { GitHubAccount } from '@renderer/types/github'
+import useText from '@renderer/hooks/text'
+import TButton from '@renderer/components/form/button'
+
+export default function GitHubAccountTable() {
+  const [accounts, setAccounts] = useState<GitHubAccount[]>([])
+  const text = useText()
+
+  useEffect(() => {
+    ;(async () => {
+      const result = await window.api.github.getAccounts()
+      if (result.success && result.data) {
+        setAccounts(result.data)
+      }
+    })()
+  }, [])
+
+  return (
+    <TColumn>
+      {accounts.map((account) => (
+        <TGrid
+          key={account.id}
+          columns={['56px', '1fr', '160px', '120px']}
+          gap={2}
+          alignItems={'center'}
+        >
+          {account.avatarUrl ? (
+            <TAvatar url={account.avatarUrl} alt={account.login} size={56} />
+          ) : (
+            <TAvatar alt={account.login} size={56} />
+          )}
+          <TColumn>
+            <TLink href={account.htmlUrl}>
+              <TText variant="subtitle">{account.login}</TText>
+            </TLink>
+            {account.name && <TText>{account.name}</TText>}
+          </TColumn>
+          <TColumn>
+            <TText>Expires date</TText>
+            <TText>{text.formatDateTime(account.expiredAt) ?? 'No expires'}</TText>
+          </TColumn>
+          <TButton>Repositories</TButton>
+        </TGrid>
+      ))}
+    </TColumn>
+  )
+}

--- a/src/renderer/hooks/text.ts
+++ b/src/renderer/hooks/text.ts
@@ -1,0 +1,16 @@
+import dayjs from 'dayjs'
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export default function useText() {
+  return {
+    formatDateTime(date: string | Date | null, options?: { defaultText?: string }): string | null {
+      if (date === null) {
+        if (options?.defaultText) {
+          return options.defaultText
+        }
+        return null
+      }
+      return dayjs(date).format('YYYY/MM/DD HH:mm:ss')
+    }
+  }
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: https://avatars.githubusercontent.com"
     />
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/renderer/routes/settings/github.tsx
+++ b/src/renderer/routes/settings/github.tsx
@@ -1,89 +1,19 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useForm } from 'react-hook-form'
-import { useState } from 'react'
-import TForm from '@renderer/components/form/form'
-import TFormItem from '@renderer/components/form/form-item'
-import TTextField from '@renderer/components/form/text-field'
-import TButton from '@renderer/components/form/button'
-import { TColumn, TRow } from '@renderer/components/layout/flex-box'
+import { TColumn } from '@renderer/components/layout/flex-box'
 import TText from '@renderer/components/display/text'
-import TAlert from '@renderer/components/feedback/alert'
-import useResolver from '@renderer/hooks/resolver'
+import GitHubAccountCreateForm from '@renderer/features/settings/github/account-create-form'
+import GitHubAccountTable from '@renderer/features/settings/github/account-table'
 
 export const Route = createFileRoute('/settings/github')({
   component: RouteComponent
 })
 
-interface FormData {
-  token: string
-}
-
 function RouteComponent() {
-  const resolver = useResolver()
-  const [processing, setProcessing] = useState(false)
-  const [successMessage, setSuccessMessage] = useState<string | null>(null)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    reset
-  } = useForm<FormData>({
-    resolver: resolver.githubPersonalAccessTokenRegister
-  })
-
-  const onSubmit = async (data: FormData) => {
-    setProcessing(true)
-    setSuccessMessage(null)
-    setErrorMessage(null)
-
-    try {
-      const result = await window.api.github.createAccount(data.token)
-
-      if (result.success && result.data) {
-        setSuccessMessage(
-          `Successfully registered GitHub account: ${result.data.login} (${result.data.name || 'No name'})`
-        )
-        reset()
-      } else {
-        setErrorMessage(result.error || 'Failed to register GitHub account')
-      }
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'An unexpected error occurred')
-    } finally {
-      setProcessing(false)
-    }
-  }
-
   return (
     <TColumn gap={2} fullWidth>
       <TText variant="title">GitHub Settings</TText>
-
-      {successMessage && <TAlert severity="success">{successMessage}</TAlert>}
-      {errorMessage && <TAlert severity="error">{errorMessage}</TAlert>}
-
-      <TForm onSubmit={handleSubmit(onSubmit)}>
-        <TFormItem label="Personal Access Token">
-          <TRow gap={2}>
-            <TTextField
-              type="password"
-              register={register('token', {
-                required: 'Personal Access Token is required'
-              })}
-              error={errors.token}
-              placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-              fullWidth
-              disabled={processing}
-            />
-            <TColumn>
-              <TButton type="submit" variant="contained" color="primary" processing={processing}>
-                Register
-              </TButton>
-            </TColumn>
-          </TRow>
-        </TFormItem>
-      </TForm>
+      <GitHubAccountCreateForm />
+      <GitHubAccountTable />
     </TColumn>
   )
 }

--- a/src/renderer/types/github.ts
+++ b/src/renderer/types/github.ts
@@ -1,0 +1,9 @@
+export interface GitHubAccount {
+  id: number
+  login: string
+  name: string | null
+  htmlUrl: string
+  avatarUrl: string | null
+  personalAccessToken: string
+  expiredAt: Date | null
+}


### PR DESCRIPTION
# 概要

登録済みのGitHubアカウント情報を設定ページに一覧表示する機能を実装

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/30

## 詳細

### IPC通信層
- `github:getAccounts` IPCハンドラーをMain Processに追加
- Preload ScriptでRenderer Processから呼び出せるAPIを公開
- TypeScript型定義（`getAccounts`メソッド）を追加

### UI層
- **GitHubAccountTable**: アカウント一覧表示コンポーネントを実装
  - TGridを使用したレスポンシブレイアウト
  - アバター画像、ユーザー名、表示名、トークン有効期限を表示
  - htmlUrlへのリンク機能
- **GitHubAccountCreateForm**: アカウント登録フォームを独立コンポーネントに分離
- 設定ページに一覧表示と登録フォームを統合

### 型定義
- Renderer側のGitHubAccount型定義を追加
- IPC経由のDate型のシリアライゼーションに対応

### セキュリティ設定
- Content Security Policy (CSP)にGitHubアバター画像ドメイン (`https://avatars.githubusercontent.com`) を追加

### バグ修正
- TListコンポーネントのListItemButtonで`selected`プロパティの型エラーを修正
- `!!`演算子で明示的にboolean型に変換

### ユーティリティ
- useTextフックで日時フォーマット機能を追加