### PR TITLE
ウィンドウの初期サイズと最小サイズを900x780に設定

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,9 @@ function createWindow(): void {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
     width: 900,
-    height: 670,
+    height: 780,
+    minWidth: 900,
+    minHeight: 780,
     show: false,
     autoHideMenuBar: true,
     ...(process.platform === 'linux' ? { icon } : {}),


### PR DESCRIPTION
# 概要

ウィンドウの初期サイズと最小サイズを900x780に設定しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/35

## 詳細

- ウィンドウの初期サイズを900x670から900x780に変更
- ウィンドウの最小サイズ（minWidth: 900, minHeight: 780）を追加
- ユーザーがウィンドウを900x780より小さくリサイズできないように制限