### PR TITLE
TDialogのタイトルバーに閉じるボタンを追加

### DIFF
--- a/src/renderer/components/feedback/dialog.tsx
+++ b/src/renderer/components/feedback/dialog.tsx
@@ -1,4 +1,14 @@
-import { Dialog, DialogActions, DialogContent, type DialogProps, DialogTitle } from '@mui/material'
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  type DialogProps,
+  DialogTitle,
+  IconButton,
+  Box,
+  Typography
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 import type { ReactNode } from 'react'
 
 interface Props {
@@ -21,7 +31,21 @@ export default function TDialog(props: Props) {
       component={props.onSubmit ? 'form' : undefined}
       onSubmit={props.onSubmit}
     >
-      {props.title && <DialogTitle>{props.title}</DialogTitle>}
+      {props.title && (
+        <DialogTitle>
+          <Box display="flex" alignItems="center" justifyContent="space-between">
+            <Typography variant="h6">{props.title}</Typography>
+            <IconButton
+              edge="end"
+              onClick={props.onClose}
+              aria-label="close"
+              sx={{ marginRight: -1 }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+      )}
       <DialogContent>{props.children}</DialogContent>
       {props.actions && <DialogActions>{props.actions}</DialogActions>}
     </Dialog>

--- a/src/renderer/features/settings/github/repository-select-dialog.tsx
+++ b/src/renderer/features/settings/github/repository-select-dialog.tsx
@@ -134,7 +134,7 @@ export default function GitHubRepositorySelectDialog(props: Props) {
 
   return (
     <TDialog open={props.open} onClose={props.onClose} title="Select Repository" size="md">
-      <TColumn gap={2} height={600}>
+      <TColumn gap={2} height={480}>
         <TFormItem label="Organization">
           <TSelect
             control={control}


### PR DESCRIPTION
# 概要

TDialogコンポーネントのタイトルバーに閉じるボタン（×）を追加しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/38

## 詳細

- TDialogコンポーネントのタイトルバーに×ボタンを追加
  - IconButton、Box、Typography、CloseIconをインポート
  - タイトルと閉じるボタンをFlexBoxで横並びに配置
  - 閉じるボタンをクリックすると`props.onClose`が呼ばれる
  - アクセシビリティのため`aria-label="close"`を追加
- repository-select-dialogの高さを600から480に調整（ウィンドウサイズ変更に合わせて）
- ウィンドウの初期サイズと最小サイズを900x780に設定（別のIssue #35の対応も含む）