### PR TITLE
プルリクエスト取得機能を実装

### DIFF
--- a/src/main/models/github.ts
+++ b/src/main/models/github.ts
@@ -15,3 +15,30 @@ export interface GitHubApiRepository {
   name: string
   htmlUrl: string
 }
+
+export interface GitHubApiPullRequestAssignee {
+  name: string
+  avatarUrl: string
+}
+
+export interface GitHubApiPullRequestReviewer {
+  name: string
+  htmlUrl: string
+  avatarUrl: string
+  comments: number
+  status: 'approved' | 'commented' | 'no-review'
+}
+
+export type GitHubPullRequestState = 'open' | 'closed'
+
+export interface GitHubApiPullRequest {
+  id: string
+  owner: GitHubApiOwner
+  repository: GitHubApiRepository
+  assignees: GitHubApiPullRequestAssignee[]
+  reviewers: GitHubApiPullRequestReviewer[]
+  title: string
+  htmlUrl: string
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
# 概要

指定したリポジトリのプルリクエスト一覧を取得する機能を実装しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/40

## 詳細

### 1. データモデルの追加

- `GitHubApiPullRequest`: プルリクエスト情報のモデル
  - id, owner, repository, assignees, reviewers, title, htmlUrl, createdAt, updatedAt
- `GitHubApiPullRequestAssignee`: アサイニー情報
  - name, avatarUrl
- `GitHubApiPullRequestReviewer`: レビュワー情報
  - name, htmlUrl, avatarUrl, comments, status（approved/commented/no-review）
- `GitHubPullRequestState`: PR状態の型（'open' | 'closed'）

### 2. API Repository機能の実装

`GitHubApiRepository.getPullRequests()`メソッドを追加：
- GitHub API `GET /repos/{owner}/{repo}/pulls` でPR一覧を取得
- 各PRに対して `GET /repos/{owner}/{repo}/pulls/{number}/reviews` でレビュー情報を取得
- レビュワー情報の集約処理：
  - requested_reviewersとactual reviewsを統合
  - レビューステータスの判定（approved優先）
  - コメント数のカウント
- Promise.allで並列処理により高速化

### 3. 関連ファイル

- `src/main/models/github.ts`: モデル定義を追加
- `src/main/repositories/github/api-repository.ts`: getPullRequestsメソッドを実装