### PR TITLE
アプリバージョンをサイドバー下部に表示する機能を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tell",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -170,6 +170,11 @@ app.whenReady().then(() => {
     }
   })
 
+  // App version IPC handler
+  ipcMain.handle('app:getVersion', () => {
+    return app.getVersion()
+  })
+
   createWindow()
 
   app.on('activate', function () {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -65,8 +65,13 @@ interface GitHubAPI {
   }>
 }
 
+interface AppAPI {
+  getVersion: () => Promise<string>
+}
+
 interface API {
   github: GitHubAPI
+  app: AppAPI
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,9 @@ const api = {
       ipcRenderer.invoke('github:removeRepository', accountId, ownerLogin, repositoryName),
     getPullRequests: (state: 'open' | 'closed') =>
       ipcRenderer.invoke('github:getPullRequests', state)
+  },
+  app: {
+    getVersion: () => ipcRenderer.invoke('app:getVersion')
   }
 }
 

--- a/src/renderer/features/system/side-bar.tsx
+++ b/src/renderer/features/system/side-bar.tsx
@@ -1,32 +1,49 @@
+import { useEffect, useState } from 'react'
 import TDrawer from '@renderer/components/navigation/drawer'
 import TList from '@renderer/components/display/list'
+import TText from '@renderer/components/display/text'
+import { TColumn } from '@renderer/components/layout/flex-box'
 import HomeIcon from '@renderer/components/display/icons/home'
 import SettingsIcon from '@renderer/components/display/icons/settings'
 import { useMatchRoute } from '@tanstack/react-router'
 
 export default function SideBar() {
   const matchRoute = useMatchRoute()
+  const [version, setVersion] = useState<string>('')
+
+  useEffect(() => {
+    const fetchVersion = async () => {
+      const appVersion = await window.api.app.getVersion()
+      setVersion(appVersion)
+    }
+    void fetchVersion()
+  }, [])
 
   return (
     <TDrawer open={true} variant={'permanent'} width={160}>
-      <TList
-        items={[
-          {
-            id: 'home',
-            content: 'Home',
-            icon: <HomeIcon />,
-            selected: matchRoute({ to: '/', fuzzy: true }) as boolean,
-            href: '/'
-          },
-          {
-            id: 'setting',
-            content: 'Settings',
-            icon: <SettingsIcon />,
-            selected: matchRoute({ to: '/settings', fuzzy: true }) as boolean,
-            href: '/settings'
-          }
-        ]}
-      />
+      <TColumn height="100%" justify="space-between">
+        <TList
+          items={[
+            {
+              id: 'home',
+              content: 'Home',
+              icon: <HomeIcon />,
+              selected: matchRoute({ to: '/', fuzzy: true }) as boolean,
+              href: '/'
+            },
+            {
+              id: 'setting',
+              content: 'Settings',
+              icon: <SettingsIcon />,
+              selected: matchRoute({ to: '/settings', fuzzy: true }) as boolean,
+              href: '/settings'
+            }
+          ]}
+        />
+        <TColumn pa={2}>
+          <TText variant="caption">v{version}</TText>
+        </TColumn>
+      </TColumn>
     </TDrawer>
   )
 }


### PR DESCRIPTION
# 概要

アプリのバージョン番号をサイドバーの下部に表示する機能を実装しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/45

## 詳細

### 実装内容

- **メインプロセス**: `app:getVersion` IPCハンドラーを追加し、Electronの`app.getVersion()`でpackage.jsonのバージョンを取得
- **Preloadスクリプト**: `window.api.app.getVersion()`をレンダラープロセスに公開
- **TypeScript型定義**: `AppAPI`インターフェースを追加し、型安全なバージョン取得を実現
- **サイドバーコンポーネント**: サイドバー下部にバージョン表示エリアを追加
  - `useEffect`でマウント時にバージョン情報を取得
  - `TColumn`を使用して縦方向のレイアウトを実装
  - `justify="space-between"`でナビゲーションとバージョン表示を上下に配置
  - バージョンは`v0.0.1`形式で表示

### 技術的詳細

- プロジェクトのコンポーネント使用ルールに準拠
- IPC通信パターンは既存のGitHub APIと同様の実装
- package.jsonのバージョンを0.0.1に更新