### PR TITLE
GitHubリリース時に各OSのバイナリを自動生成するワークフローを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  check-version:
+    name: Check Version Update
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get package.json version
+        id: get-version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $VERSION"
+
+      - name: Get latest release
+        id: latest-release
+        run: |
+          LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No previous releases found"
+            echo "is_first_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "Latest release tag: $LATEST_TAG"
+            echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+            echo "is_first_release=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Compare versions
+        if: steps.latest-release.outputs.is_first_release != 'true'
+        run: |
+          CURRENT_VERSION="${{ steps.get-version.outputs.version }}"
+          LATEST_TAG="${{ steps.latest-release.outputs.latest_tag }}"
+          LATEST_VERSION="${LATEST_TAG#v}"
+
+          echo "Comparing versions: $CURRENT_VERSION vs $LATEST_VERSION"
+
+          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+            echo "Error: Version $CURRENT_VERSION is the same as the latest release"
+            exit 1
+          fi
+
+          # Simple version comparison (assuming semver format)
+          if [ "$(printf '%s\n' "$LATEST_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" = "$CURRENT_VERSION" ] && [ "$CURRENT_VERSION" != "$LATEST_VERSION" ]; then
+            echo "Error: Version $CURRENT_VERSION is older than the latest release $LATEST_VERSION"
+            exit 1
+          fi
+
+          echo "Version check passed: $CURRENT_VERSION > $LATEST_VERSION"
+
+  build-windows:
+    name: Build Windows
+    needs: check-version
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Windows app
+        run: npm run build:win
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: |
+            dist/*.exe
+          retention-days: 7
+
+      - name: Upload to release
+        run: |
+          $files = Get-ChildItem -Path dist -Filter *.exe
+          foreach ($file in $files) {
+            gh release upload ${{ github.event.release.tag_name }} $file.FullName
+          }
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  build-macos:
+    name: Build macOS
+    needs: check-version
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build macOS app
+        run: npm run build:mac
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-build
+          path: |
+            dist/*.dmg
+          retention-days: 7
+
+      - name: Upload to release
+        run: |
+          for file in dist/*.dmg; do
+            if [ -f "$file" ]; then
+              gh release upload ${{ github.event.release.tag_name }} "$file"
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  build-linux:
+    name: Build Linux
+    needs: check-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y snapcraft
+          npm ci
+
+      - name: Build Linux app
+        run: npm run build:linux
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-build
+          path: |
+            dist/*.AppImage
+            dist/*.snap
+            dist/*.deb
+          retention-days: 7
+
+      - name: Upload to release
+        run: |
+          for file in dist/*.AppImage dist/*.snap dist/*.deb; do
+            if [ -f "$file" ]; then
+              gh release upload ${{ github.event.release.tag_name }} "$file"
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -32,3 +32,45 @@ $ npm run build:mac
 # For Linux
 $ npm run build:linux
 ```
+
+## Release Process
+
+このプロジェクトでは、GitHub Actionsを使用して自動的にリリースバイナリを生成します。
+
+### リリース手順
+
+1. **バージョンの更新**
+
+   ```bash
+   # package.jsonのversionを更新（例: 0.0.1 -> 0.0.2）
+   npm version patch  # パッチバージョンアップ
+   npm version minor  # マイナーバージョンアップ
+   npm version major  # メジャーバージョンアップ
+   ```
+
+2. **変更をコミットしてプッシュ**
+
+   ```bash
+   git add package.json
+   git commit -m "バージョンを0.0.2に更新"
+   git push
+   ```
+
+3. **GitHubでリリースを作成**
+   - GitHubのリポジトリページで "Releases" → "Create a new release" をクリック
+   - タグ名を入力（例: `v0.0.2`）
+   - リリースタイトルと説明を入力
+   - "Publish release" をクリック
+
+4. **自動ビルド**
+   - GitHub Actionsが自動的に起動し、以下のバイナリを生成します：
+     - Windows: `tell-{version}-setup.exe`
+     - macOS: `tell-{version}.dmg`
+     - Linux: `tell-{version}.AppImage`, `tell-{version}.snap`, `tell-{version}.deb`
+   - 生成されたバイナリは自動的にリリースページにアップロードされます
+
+### バージョン管理
+
+- リリース時には、前回のリリースからバージョンが更新されていることが自動的にチェックされます
+- 同じバージョンまたは古いバージョンでリリースしようとすると、ワークフローがエラーで終了します
+- バージョン番号はSemantic Versioning（`MAJOR.MINOR.PATCH`）に従ってください


### PR DESCRIPTION
# 概要

GitHubでリリースを作成したときに、Windows、macOS、Linuxの各OSのバイナリを自動的に生成するGitHub Actionsワークフローを追加しました。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/46

## 詳細

### 実装内容

#### 1. GitHub Actionsリリースワークフロー（`.github/workflows/release.yml`）

**トリガー**
- GitHubでリリースを作成したときに自動実行（`release: created`イベント）

**ジョブ構成**

1. **check-version**: バージョン確認ジョブ
   - package.jsonのバージョンを取得
   - GitHub APIで最新リリースのタグを取得
   - バージョンを比較し、更新されているかチェック
   - 同じまたは古いバージョンの場合はエラーで終了
   - 初回リリースの場合はチェックをスキップ

2. **build-windows**: Windows用ビルドジョブ
   - windows-latestで実行
   - `npm run build:win`でNSISインストーラーを生成
   - `tell-{version}-setup.exe`をリリースアセットとしてアップロード

3. **build-macos**: macOS用ビルドジョブ
   - macos-latestで実行
   - `npm run build:mac`でDMGファイルを生成
   - `tell-{version}.dmg`をリリースアセットとしてアップロード

4. **build-linux**: Linux用ビルドジョブ
   - ubuntu-latestで実行
   - `npm run build:linux`でAppImage、snap、debパッケージを生成
   - 各ファイルをリリースアセットとしてアップロード

#### 2. ドキュメント更新（`README.md`）

**追加したセクション**
- Release Process: リリースプロセスの全体説明
- リリース手順: ステップバイステップの手順
  1. バージョン更新（`npm version`コマンド）
  2. 変更のコミットとプッシュ
  3. GitHubでリリースを作成
  4. 自動ビルドの開始と完了
- バージョン管理: バージョンチェックのルールとSemantic Versioningの説明

### 技術的詳細

- Node.js 20を使用
- actions/checkout@v4、actions/setup-node@v4、actions/upload-artifact@v4を使用
- GitHub CLIでリリースアセットをアップロード
- セマンティックバージョニングに基づくバージョン比較
- 各OSのビルド成果物を7日間保持（アーティファクト）

### 使用方法

1. package.jsonのバージョンを更新
2. 変更をコミット・プッシュ
3. GitHubでリリースを作成（タグ名: `v{version}`）
4. GitHub Actionsが自動的に各OSのバイナリを生成・アップロード