### PR TITLE
リリースタグから'release/'プレフィックスを削除するように修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,11 @@ jobs:
         run: |
           CURRENT_VERSION="${{ steps.get-version.outputs.version }}"
           LATEST_TAG="${{ steps.latest-release.outputs.latest_tag }}"
-          LATEST_VERSION="${LATEST_TAG#v}"
+
+          # Remove 'release/' prefix if present
+          LATEST_VERSION="${LATEST_TAG#release/}"
+          # Remove 'v' prefix if present
+          LATEST_VERSION="${LATEST_VERSION#v}"
 
           echo "Comparing versions: $CURRENT_VERSION vs $LATEST_VERSION"
 


### PR DESCRIPTION
- タグ形式 release/v0.0.2 に対応
- release/ と v の両方のプレフィックスを順次削除
- バージョン比較が正しく動作するように改善

# 概要

<!-- 一行程度の短い文章でプルリクエストの概要を記述する -->

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/{issue id}

## 詳細

<!-- 具体的に追加・変更した内容を記述する -->
