### PR TITLE
GitHub APIのレート制限エラーに対応

### DIFF
--- a/src/renderer/features/github/pull-requests-panel.tsx
+++ b/src/renderer/features/github/pull-requests-panel.tsx
@@ -87,10 +87,15 @@ export default function GitHubPullRequestsPanel(props: Props) {
     // 初回読み込み
     void fetchPullRequests(true)
 
-    // 60秒ごとにポーリング
-    const intervalId = setInterval(() => {
-      void fetchPullRequests(false)
-    }, 60000)
+    // 5分ごとにポーリング
+    // GitHub APIのレート制限: 5,000リクエスト/時間
+    // 5分間隔であれば、最大12リクエスト/時間となり、レート制限に余裕がある
+    const intervalId = setInterval(
+      () => {
+        void fetchPullRequests(false)
+      },
+      5 * 60 * 1000
+    ) // 5分 = 300,000ms
 
     // クリーンアップ
     return () => {


### PR DESCRIPTION
# 概要

GitHub APIのレート制限エラーを回避するため、ポーリング間隔を延長し、エラーハンドリングを改善

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/58

## 詳細

### ポーリング間隔の調整
- プルリクエストのポーリング間隔を60秒から5分（300秒）に延長
- GitHub APIのレート制限（5,000リクエスト/時間）に対して十分な余裕を確保
- 5分間隔では最大12リクエスト/時間となり、複数リポジトリでもレート制限に達しにくい

### レート制限エラーのハンドリング改善
- `handleApiError()`メソッドを追加してエラーハンドリングを統一
- 403 Forbiddenレスポンスで"rate limit exceeded"メッセージを検出
- `x-ratelimit-reset`ヘッダーから次回リセット時刻を取得
- ユーザーに具体的な待機時間を通知するエラーメッセージを表示

### 影響範囲
- `src/main/repositories/github/api-repository.ts`: エラーハンドリングロジックの追加
- `src/renderer/features/github/pull-requests-panel.tsx`: ポーリング間隔の変更