### PR TITLE
トーストメッセージシステムの実装

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,12 +28,7 @@ export default tseslint.config(
       ...eslintPluginReactHooks.configs.recommended.rules,
       ...eslintPluginReactRefresh.configs.vite.rules,
       'import/no-relative-packages': 'error',
-      'import/no-relative-parent-imports': 'error'
-    }
-  },
-  {
-    files: ['**/*.tsx'],
-    rules: {
+      'import/no-relative-parent-imports': 'error',
       '@typescript-eslint/explicit-function-return-type': 'off'
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "electron-updater": "^6.3.9",
         "react-hook-form": "^7.66.1",
         "react-icons": "^5.5.0",
-        "yup": "^1.7.1"
+        "yup": "^1.7.1",
+        "zustand": "^5.0.9"
       },
       "devDependencies": {
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -12302,6 +12303,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
+      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "electron-updater": "^6.3.9",
     "react-hook-form": "^7.66.1",
     "react-icons": "^5.5.0",
-    "yup": "^1.7.1"
+    "yup": "^1.7.1",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/src/renderer/features/github/pull-requests-panel.tsx
+++ b/src/renderer/features/github/pull-requests-panel.tsx
@@ -9,6 +9,7 @@ import TCircularProgress from '@renderer/components/feedback/circular-progress'
 import GitHubIcon from '@renderer/components/display/icons/github'
 import TIconButton from '@renderer/components/form/icon-button'
 import { IoRefresh } from 'react-icons/io5'
+import useMessage from '@renderer/hooks/message'
 
 type Props = {
   state: 'open' | 'closed'
@@ -46,10 +47,10 @@ function groupingPullRequests(pullRequests: GitHubApiPullRequest[]): OwnerReposi
 }
 
 export default function GitHubPullRequestsPanel(props: Props) {
+  const message = useMessage()
   const [pullRequests, setPullRequests] = useState<GitHubApiPullRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   const fetchPullRequests = useCallback(
     async (showLoading: boolean = false): Promise<void> => {
@@ -59,15 +60,14 @@ export default function GitHubPullRequestsPanel(props: Props) {
         } else {
           setRefreshing(true)
         }
-        setError(null)
         const result = await window.api.github.getPullRequests(props.state)
         if (result.success && result.data) {
           setPullRequests(result.data as GitHubApiPullRequest[])
         } else {
-          setError(result.error || 'Failed to fetch pull requests')
+          message.setMessage('error', result.error || 'Failed to fetch pull requests')
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Unknown error occurred')
+        message.setMessage('error', err instanceof Error ? err.message : 'Unknown error occurred')
       } finally {
         if (showLoading) {
           setLoading(false)
@@ -76,7 +76,7 @@ export default function GitHubPullRequestsPanel(props: Props) {
         }
       }
     },
-    [props.state]
+    [props.state, message]
   )
 
   const handleRefresh = useCallback(() => {
@@ -120,8 +120,6 @@ export default function GitHubPullRequestsPanel(props: Props) {
           <TCircularProgress size={40} />
           <TText>Loading pull requests...</TText>
         </TColumn>
-      ) : error ? (
-        <TAlert severity="error">{error}</TAlert>
       ) : pullRequests.length === 0 ? (
         <TAlert severity={'info'}>No pull requests</TAlert>
       ) : (

--- a/src/renderer/features/settings/github/account-create-form.tsx
+++ b/src/renderer/features/settings/github/account-create-form.tsx
@@ -1,22 +1,21 @@
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { TColumn, TRow } from '@renderer/components/layout/flex-box'
-import TAlert from '@renderer/components/feedback/alert'
 import TForm from '@renderer/components/form/form'
 import TFormItem from '@renderer/components/form/form-item'
 import TTextField from '@renderer/components/form/text-field'
 import TButton from '@renderer/components/form/button'
 import useResolver from '@renderer/hooks/resolver'
+import useMessage from '@renderer/hooks/message'
 
 interface FormData {
   token: string
 }
 
 export default function GitHubAccountCreateForm() {
+  const message = useMessage()
   const resolver = useResolver()
   const [processing, setProcessing] = useState(false)
-  const [successMessage, setSuccessMessage] = useState<string | null>(null)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const {
     register,
@@ -29,22 +28,24 @@ export default function GitHubAccountCreateForm() {
 
   const onSubmit = async (data: FormData) => {
     setProcessing(true)
-    setSuccessMessage(null)
-    setErrorMessage(null)
 
     try {
       const result = await window.api.settings.github.addAccount(data.token)
 
       if (result.success && result.data) {
-        setSuccessMessage(
+        message.setMessage(
+          'success',
           `Successfully registered GitHub account: ${result.data.login} (${result.data.name || 'No name'})`
         )
         reset()
       } else {
-        setErrorMessage(result.error || 'Failed to register GitHub account')
+        message.setMessage('error', result.error || 'Failed to register GitHub account')
       }
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'An unexpected error occurred')
+      message.setMessage(
+        'error',
+        error instanceof Error ? error.message : 'An unexpected error occurred'
+      )
     } finally {
       setProcessing(false)
     }
@@ -52,9 +53,6 @@ export default function GitHubAccountCreateForm() {
 
   return (
     <TColumn gap={2} fullWidth>
-      {successMessage && <TAlert severity="success">{successMessage}</TAlert>}
-      {errorMessage && <TAlert severity="error">{errorMessage}</TAlert>}
-
       <TForm onSubmit={handleSubmit(onSubmit)}>
         <TFormItem label="Personal Access Token">
           <TRow gap={2}>

--- a/src/renderer/features/system/message.tsx
+++ b/src/renderer/features/system/message.tsx
@@ -1,0 +1,10 @@
+import TSnackbar from '@renderer/components/feedback/snackbar'
+import useMessage from '@renderer/hooks/message'
+
+export default function SystemMessage() {
+  const { severity, message, clearMessage } = useMessage()
+
+  if (severity === null || message === null) return null
+
+  return <TSnackbar open={true} message={message} severity={severity} onClose={clearMessage} />
+}

--- a/src/renderer/hooks/message.ts
+++ b/src/renderer/hooks/message.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand/react'
+
+export type Severity = 'error' | 'info' | 'success'
+
+type MessageStore = {
+  severity: Severity | null
+  message: string | null
+  setMessage: (severity: Severity, message: string) => void
+  clearMessage: () => void
+}
+
+const useMessageStore = create<MessageStore>((set) => ({
+  severity: null,
+  message: null,
+  setMessage: (severity: Severity, message: string) => {
+    set({ severity, message })
+  },
+  clearMessage: () => {
+    set({ severity: null, message: null })
+  }
+}))
+
+export default function useMessage() {
+  const store = useMessageStore()
+
+  return {
+    severity: store.severity,
+    message: store.message,
+    setMessage: store.setMessage,
+    clearMessage: store.clearMessage
+  }
+}

--- a/src/renderer/hooks/text.ts
+++ b/src/renderer/hooks/text.ts
@@ -1,7 +1,6 @@
 import dayjs, { extend } from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default function useText() {
   extend(relativeTime)
   return {

--- a/src/renderer/routes/__root.tsx
+++ b/src/renderer/routes/__root.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, Outlet } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import SideBar from '@renderer/features/system/side-bar'
 import { TColumn } from '@renderer/components/layout/flex-box'
+import SystemMessage from '@renderer/features/system/message'
 
 export const Route = createRootRoute({
   component: () => (
@@ -10,6 +11,7 @@ export const Route = createRootRoute({
       <TColumn ml={20} px={2} py={2}>
         <Outlet />
       </TColumn>
+      <SystemMessage />
       <TanStackRouterDevtools />
     </>
   )


### PR DESCRIPTION
# 概要

Zustandを使用したグローバルなトーストメッセージシステムを実装

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/49

## 詳細

### 追加機能
- Zustandを使用したグローバルなメッセージ状態管理システムの実装
- トーストメッセージ表示用のSystemMessageコンポーネントの追加
- useMessage フックによるメッセージ管理APIの提供

### 変更内容
- GitHub PR一覧パネル: ローカルなエラー表示をトーストメッセージに置き換え
- GitHubアカウント作成フォーム: 成功/エラーメッセージをトーストメッセージに置き換え
- GitHub APIリポジトリ: レート制限エラーの検出と適切なエラーメッセージの返却
- ESLint設定: TypeScript関数の戻り値型指定ルールを `.tsx` ファイル全体に適用するよう調整

### 依存関係の追加
- zustand: ^5.0.9