### PR TITLE
プルリクエスト読み込みの無限ループを修正

### DIFF
--- a/src/renderer/features/github/pull-requests-panel.tsx
+++ b/src/renderer/features/github/pull-requests-panel.tsx
@@ -76,7 +76,9 @@ export default function GitHubPullRequestsPanel(props: Props) {
         }
       }
     },
-    [props.state, message]
+    // message全体を依存配列に含めると無限ループが発生するため、setMessageのみを含める
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [props.state, message.setMessage]
   )
 
   const handleRefresh = useCallback(() => {


### PR DESCRIPTION
# 概要

homeページでプルリクエストの読み込みが無限に発生していた問題を修正

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/65

## 詳細

### 問題

- `GitHubPullRequestsPanel` コンポーネントで、`fetchPullRequests` 関数の依存配列に `message` オブジェクト全体が含まれていた
- `useMessage()` フックが毎回新しいオブジェクトを返すため、以下の無限ループが発生
  1. コンポーネントレンダリング → 新しい `message` オブジェクト生成
  2. `fetchPullRequests` が再生成される
  3. useEffect が再実行される
  4. API呼び出しとstate更新
  5. 再レンダリング → 1に戻る

### 修正内容

- `fetchPullRequests` の依存配列を `[props.state, message]` から `[props.state, message.setMessage]` に変更
- `message.setMessage` は安定した参照を持つ関数なので、無限ループが解消される
- ESLint の `react-hooks/exhaustive-deps` 警告を抑制するコメントを追加（理由を明記）

### 変更ファイル

- `src/renderer/features/github/pull-requests-panel.tsx`
  - 依存配列の修正（79-81行目）
  - 無限ループ防止のための説明コメント追加