### PR TITLE
自動生成ファイル(routeTree.gen.ts)をPrettierの対象から除外

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ pnpm-lock.yaml
 LICENSE.md
 tsconfig.json
 tsconfig.*.json
+src/renderer/routeTree.gen.ts


### PR DESCRIPTION
# 概要

自動生成ファイル(routeTree.gen.ts)をPrettierの対象から除外する設定を追加

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/73

## 詳細

- `.prettierignore`に`src/renderer/routeTree.gen.ts`を追加
- @tanstack/router-pluginによって自動生成されるファイルをフォーマット対象から除外
- ESLintの設定は既に対応済みであったため変更なし
- これによりコミット時に不要なフォーマット差分が発生しなくなります