### PR TITLE
ウィンドウタイトルをアプリ名「tell」に変更

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Electron</title>
+    <title>tell</title>
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"


### PR DESCRIPTION
# 概要

ウィンドウタイトルをデフォルトの「Electron」からアプリケーション名「tell」に変更

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/82

## 詳細

- `src/renderer/index.html`のtitleタグを修正
- デフォルトの「Electron」から正式なアプリ名「tell」（小文字）に変更
- ウィンドウタイトル、タブ名、タスクバーでの表示が「tell」になる