### PR TITLE
本番環境でTanStack Routerのデバッグメニューを非表示に

### DIFF
--- a/src/renderer/routes/__root.tsx
+++ b/src/renderer/routes/__root.tsx
@@ -12,7 +12,7 @@ export const Route = createRootRoute({
         <Outlet />
       </TColumn>
       <SystemMessage />
-      <TanStackRouterDevtools />
+      {process.env.NODE_ENV === 'development' && <TanStackRouterDevtools />}
     </>
   )
 })


### PR DESCRIPTION
# 概要

本番環境でTanStack Routerのデバッグメニューを非表示にして、開発環境でのみ表示するように変更

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/81

## 詳細

- `src/renderer/routes/__root.tsx`でDevToolsコンポーネントを条件付きレンダリングに変更
- `process.env.NODE_ENV === 'development'`の場合のみDevToolsを表示
- 本番ビルドではDevTools関連のコードがバンドルから除外され、約92KBのファイルサイズ削減
- 開発環境では引き続きデバッグメニューが利用可能