### PR TITLE
GitHubアカウント登録後の表示更新を修正

### DIFF
--- a/src/renderer/features/settings/github/account-create-form.tsx
+++ b/src/renderer/features/settings/github/account-create-form.tsx
@@ -7,12 +7,17 @@ import TTextField from '@renderer/components/form/text-field'
 import TButton from '@renderer/components/form/button'
 import useResolver from '@renderer/hooks/resolver'
 import useMessage from '@renderer/hooks/message'
+import { GitHubAccount } from '@renderer/types/github'
 
 interface FormData {
   token: string
 }
 
-export default function GitHubAccountCreateForm() {
+interface Props {
+  onAccountAdded?: (account: GitHubAccount) => void
+}
+
+export default function GitHubAccountCreateForm({ onAccountAdded }: Props) {
   const message = useMessage()
   const resolver = useResolver()
   const [processing, setProcessing] = useState(false)
@@ -38,6 +43,10 @@ export default function GitHubAccountCreateForm() {
           `Successfully registered GitHub account: ${result.data.login} (${result.data.name || 'No name'})`
         )
         reset()
+        // 親コンポーネントに新しいアカウント情報を通知
+        if (onAccountAdded) {
+          onAccountAdded(result.data)
+        }
       } else {
         message.setMessage('error', result.error || 'Failed to register GitHub account')
       }

--- a/src/renderer/features/settings/github/account-table.tsx
+++ b/src/renderer/features/settings/github/account-table.tsx
@@ -3,26 +3,20 @@ import TAvatar from '@renderer/components/display/avatar'
 import TText from '@renderer/components/display/text'
 import TLink from '@renderer/components/navigation/link'
 import { TColumn } from '@renderer/components/layout/flex-box'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { GitHubAccount } from '@renderer/types/github'
 import useText from '@renderer/hooks/text'
 import TButton from '@renderer/components/form/button'
 import GitHubRepositorySelectDialog from './repository-select-dialog'
 
-export default function GitHubAccountTable() {
-  const [accounts, setAccounts] = useState<GitHubAccount[]>([])
+interface Props {
+  accounts: GitHubAccount[]
+}
+
+export default function GitHubAccountTable({ accounts }: Props) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [selectedAccountId, setSelectedAccountId] = useState<number | null>(null)
   const text = useText()
-
-  useEffect(() => {
-    ;(async () => {
-      const result = await window.api.settings.github.getAccounts()
-      if (result.success && result.data) {
-        setAccounts(result.data)
-      }
-    })()
-  }, [])
 
   const handleOpenDialog = (accountId: number) => {
     setSelectedAccountId(accountId)

--- a/src/renderer/routes/settings/github.tsx
+++ b/src/renderer/routes/settings/github.tsx
@@ -3,17 +3,38 @@ import { TColumn } from '@renderer/components/layout/flex-box'
 import TText from '@renderer/components/display/text'
 import GitHubAccountCreateForm from '@renderer/features/settings/github/account-create-form'
 import GitHubAccountTable from '@renderer/features/settings/github/account-table'
+import { useEffect, useState } from 'react'
+import { GitHubAccount } from '@renderer/types/github'
 
 export const Route = createFileRoute('/settings/github')({
   component: RouteComponent
 })
 
 function RouteComponent() {
+  const [accounts, setAccounts] = useState<GitHubAccount[]>([])
+
+  // 初回読み込み
+  useEffect(() => {
+    loadAccounts()
+  }, [])
+
+  const loadAccounts = async () => {
+    const result = await window.api.settings.github.getAccounts()
+    if (result.success && result.data) {
+      setAccounts(result.data)
+    }
+  }
+
+  const handleAccountAdded = (account: GitHubAccount) => {
+    // 新しいアカウントを既存のリストに追加
+    setAccounts((prev) => [...prev, account])
+  }
+
   return (
     <TColumn gap={2} fullWidth>
       <TText variant="title">GitHub Settings</TText>
-      <GitHubAccountCreateForm />
-      <GitHubAccountTable />
+      <GitHubAccountCreateForm onAccountAdded={handleAccountAdded} />
+      <GitHubAccountTable accounts={accounts} />
     </TColumn>
   )
 }


### PR DESCRIPTION
# 概要

GitHubアカウント登録後に即座にアカウント情報が表示されるよう状態管理を改善

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/83

## 詳細

### 問題点
- Personal Access Token登録後、アカウント情報がテーブルに表示されない
- ページをリロードしないと新しく登録したアカウントが表示されない状態だった

### 変更内容

**状態管理の改善**
- `src/renderer/routes/settings/github.tsx`
  - アカウントリストの状態管理を親コンポーネントに移動
  - 初回読み込み用の `loadAccounts` 関数を追加
  - 新規アカウント追加用の `handleAccountAdded` コールバックを実装

**GitHubAccountCreateFormの更新**
- `src/renderer/features/settings/github/account-create-form.tsx`
  - `onAccountAdded` プロップを追加
  - 登録成功時に親コンポーネントへ新しいアカウント情報を通知する処理を追加

**GitHubAccountTableの更新**
- `src/renderer/features/settings/github/account-table.tsx`
  - 内部でのアカウント情報取得処理を削除
  - `accounts` をプロップとして受け取る方式に変更
  - useEffectによる初回読み込みを削除

### 技術的な詳細
- 親コンポーネントが単一の情報源（Single Source of Truth）として機能するよう修正
- コンポーネント間の状態が適切に同期されるようになった
- 不要なAPI呼び出しを削減