### PR TITLE
404ページを自動的にホームページへリダイレクトする機能を追加

### DIFF
--- a/src/renderer/routeTree.gen.ts
+++ b/src/renderer/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as DebugRouteImport } from './routes/debug'
+import { Route as SplatRouteImport } from './routes/$'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as SettingsGithubRouteImport } from './routes/settings/github'
@@ -24,6 +25,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const DebugRoute = DebugRouteImport.update({
   id: '/debug',
   path: '/debug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SplatRoute = SplatRouteImport.update({
+  id: '/$',
+  path: '/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -49,6 +55,7 @@ const DebugStoreRoute = DebugStoreRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/debug': typeof DebugRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/debug/store': typeof DebugStoreRoute
@@ -57,6 +64,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/debug': typeof DebugRouteWithChildren
   '/debug/store': typeof DebugStoreRoute
   '/settings/github': typeof SettingsGithubRoute
@@ -65,6 +73,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/debug': typeof DebugRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/debug/store': typeof DebugStoreRoute
@@ -75,16 +84,18 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/$'
     | '/debug'
     | '/settings'
     | '/debug/store'
     | '/settings/github'
     | '/settings/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/debug' | '/debug/store' | '/settings/github' | '/settings'
+  to: '/' | '/$' | '/debug' | '/debug/store' | '/settings/github' | '/settings'
   id:
     | '__root__'
     | '/'
+    | '/$'
     | '/debug'
     | '/settings'
     | '/debug/store'
@@ -94,6 +105,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SplatRoute: typeof SplatRoute
   DebugRoute: typeof DebugRouteWithChildren
   SettingsRoute: typeof SettingsRouteWithChildren
 }
@@ -112,6 +124,13 @@ declare module '@tanstack/react-router' {
       path: '/debug'
       fullPath: '/debug'
       preLoaderRoute: typeof DebugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$': {
+      id: '/$'
+      path: '/$'
+      fullPath: '/$'
+      preLoaderRoute: typeof SplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -171,6 +190,7 @@ const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SplatRoute: SplatRoute,
   DebugRoute: DebugRouteWithChildren,
   SettingsRoute: SettingsRouteWithChildren,
 }

--- a/src/renderer/routes/$.tsx
+++ b/src/renderer/routes/$.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute, Navigate } from '@tanstack/react-router'
+
+// Catch-all route for 404 pages - redirects to home
+export const Route = createFileRoute('/$')({
+  component: () => <Navigate to="/" replace />
+})


### PR DESCRIPTION
## 概要
存在しないページ（404エラー）にアクセスした際に、自動的にホームページへリダイレクトする機能を実装しました。

## 対応Issue
- fixes: https://github.com/pkshimizu/tell/issues/90

## 詳細

### 実装内容
- **キャッチオールルートの追加**
  - `src/renderer/routes/$.tsx` を新規作成
  - TanStack Routerのスプラットルート機能を使用
  - 未定義のルートを全てキャッチ

### リダイレクト処理
- `Navigate` コンポーネントを使用した自動リダイレクト
- `replace` オプションで履歴を置き換え
- ホームページ（`/`）へ即座に遷移

### 技術的な詳細
- ファイルベースルーティングの仕組みを活用
- `routeTree.gen.ts` は自動生成により更新
- シンプルで保守性の高い実装

### 動作確認
以下のような存在しないURLにアクセスすると、自動的にホームページへリダイレクトされます：
- `/#/nonexistent`
- `/#/test/404`
- `/#/any/invalid/path`

### メリット
- ユーザーエクスペリエンスの向上
- エラーページを表示せずにスムーズな復帰
- Electronアプリケーションに適した挙動