### PR TITLE
GitHubリポジトリ選択ダイアログのスクロールバー重複表示を修正

### DIFF
--- a/src/renderer/components/feedback/dialog.tsx
+++ b/src/renderer/components/feedback/dialog.tsx
@@ -46,7 +46,7 @@ export default function TDialog(props: Props) {
           </Box>
         </DialogTitle>
       )}
-      <DialogContent>{props.children}</DialogContent>
+      <DialogContent sx={{ overflow: 'hidden', padding: 2 }}>{props.children}</DialogContent>
       {props.actions && <DialogActions>{props.actions}</DialogActions>}
     </Dialog>
   )

--- a/src/renderer/features/settings/github/repository-select-dialog.tsx
+++ b/src/renderer/features/settings/github/repository-select-dialog.tsx
@@ -134,7 +134,7 @@ export default function GitHubRepositorySelectDialog(props: Props) {
 
   return (
     <TDialog open={props.open} onClose={props.onClose} title="Select Repository" size="md">
-      <TColumn gap={2} height={480}>
+      <TColumn gap={2} height={500}>
         <TFormItem label="Organization">
           <TSelect
             control={control}
@@ -146,10 +146,20 @@ export default function GitHubRepositorySelectDialog(props: Props) {
           />
         </TFormItem>
 
-        {loading && <TCircularProgress size={40} />}
+        {loading && (
+          <TColumn height={420} justify="center" align="center">
+            <TCircularProgress size={40} />
+          </TColumn>
+        )}
+
+        {!loading && selectedOwner && repositories.length === 0 && (
+          <TColumn height={420} justify="center" align="center">
+            <TText>No repositories found</TText>
+          </TColumn>
+        )}
 
         {!loading && repositories.length > 0 && (
-          <TColumn gap={1}>
+          <TColumn gap={1} height={420}>
             <TText variant="caption">Repositories</TText>
             <TTextField register={register('filterKeyword')} />
             <TList
@@ -171,8 +181,14 @@ export default function GitHubRepositorySelectDialog(props: Props) {
                   )
                 }
               })}
-              height={460}
+              height={350}
             />
+          </TColumn>
+        )}
+
+        {!loading && !selectedOwner && (
+          <TColumn height={420} justify="center" align="center">
+            <TText>Select an organization to view repositories</TText>
           </TColumn>
         )}
       </TColumn>


### PR DESCRIPTION
# 概要

GitHubリポジトリ選択ダイアログで発生していたスクロールバーの重複表示問題を修正

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/94

## 詳細

- ダイアログの高さを500pxに固定し、コンテンツによる高さ変動を防止
- DialogContentのオーバーフロー設定を調整（`overflow: 'hidden'`）し、不要なスクロールバーを削除
- 各状態に対応したレイアウトを実装
  - 未選択時: "Select an organization to view repositories"メッセージを表示
  - ローディング中: CircularProgressを中央表示
  - リポジトリなし: "No repositories found"メッセージを表示
  - リポジトリあり: リポジトリリストを表示（高さ350px）
- リポジトリリストのみにスクロールバーが表示されるように修正