### PR TITLE
Electron標準メニューバーの不要な項目を削除

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,13 +67,12 @@ function createWindow(): void {
 function setupApplicationMenu(): void {
   if (process.platform === 'darwin') {
     // macOS requires a menu bar, so create a minimal one with only app menu
-    const appName = 'tell'
     const template: Electron.MenuItemConstructorOptions[] = [
       {
-        label: appName,
+        label: app.name,
         submenu: [
           {
-            label: 'About ' + appName,
+            label: 'About ' + app.name,
             role: 'about'
           },
           { type: 'separator' },


### PR DESCRIPTION
## 概要
Electron標準メニューバーの不要な項目を削除し、アプリケーションに必要な最小限のメニューのみを残す

## 対応Issue
- fixes: https://github.com/pkshimizu/tell/issues/84

## 詳細
- macOSではアプリメニュー（About、Quit）のみを残す最小構成に変更
- Windows/Linuxではメニューバーを完全に削除
- メニューラベルにapp.nameを使用してアプリ名を正しく表示
- 不要なFile、Edit、View、Window、Helpメニューを削除

## テスト
- [x] macOSでメニューバーが「tell」メニューのみ表示されることを確認
- [x] Windows/Linuxでメニューバーが完全に非表示になることを確認
- [x] Aboutダイアログとアプリケーション終了が正常に動作することを確認