### PR TITLE
サイドバーの選択状態が正しく更新されない問題を修正

### DIFF
--- a/src/renderer/features/system/side-bar.tsx
+++ b/src/renderer/features/system/side-bar.tsx
@@ -6,10 +6,10 @@ import { TColumn } from '@renderer/components/layout/flex-box'
 import HomeIcon from '@renderer/components/display/icons/home'
 import SettingsIcon from '@renderer/components/display/icons/settings'
 import BugIcon from '@renderer/components/display/icons/bug'
-import { useMatchRoute } from '@tanstack/react-router'
+import { useLocation } from '@tanstack/react-router'
 
 export default function SideBar() {
-  const matchRoute = useMatchRoute()
+  const location = useLocation()
   const [version, setVersion] = useState<string>('')
 
   useEffect(() => {
@@ -21,18 +21,20 @@ export default function SideBar() {
   }, [])
 
   const menuItems = useMemo(() => {
+    const pathname = location.pathname
+
     const items = [
       {
         id: 'home',
         icon: <HomeIcon />,
-        selected: matchRoute({ to: '/', fuzzy: true }) as boolean,
+        selected: pathname === '/',
         href: '/',
         tooltip: 'Home'
       },
       {
         id: 'setting',
         icon: <SettingsIcon />,
-        selected: matchRoute({ to: '/settings', fuzzy: true }) as boolean,
+        selected: pathname.startsWith('/settings'),
         href: '/settings',
         tooltip: 'Settings'
       }
@@ -43,14 +45,14 @@ export default function SideBar() {
       items.push({
         id: 'debug',
         icon: <BugIcon />,
-        selected: matchRoute({ to: '/debug/store', fuzzy: true }) as boolean,
+        selected: pathname.startsWith('/debug'),
         href: '/debug/store',
         tooltip: 'Debug Store'
       })
     }
 
     return items
-  }, [matchRoute])
+  }, [location.pathname])
 
   return (
     <TDrawer open={true} variant={'permanent'} width={64}>


### PR DESCRIPTION
# 概要

サイドバーのメニュー選択状態がページ遷移時に正しく更新されるように修正

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/103

## 詳細

### 問題の原因
- `useMatchRoute` フックを使った判定で、`fuzzy: true` オプションによりHomeページ (`/`) が全てのルートにマッチしてしまっていた
- 結果として、どのページに遷移してもHomeが常に選択状態になっていた

### 修正内容
- **ルート判定方法を変更**
  - `useMatchRoute` から `useLocation` フックへ変更
  - パスの直接比較による確実な選択状態判定を実装

- **選択状態の判定ロジック**
  - Home: `pathname === '/'` (ルートパスの完全一致のみ)
  - Settings: `pathname.startsWith('/settings')` (設定ページとその配下)
  - Debug: `pathname.startsWith('/debug')` (デバッグページとその配下)

### 動作確認
- Homeページで「Home」アイコンのみハイライト表示 ✅
- Settingsページで「Settings」アイコンのみハイライト表示 ✅
- Debugページで「Debug」アイコンのみハイライト表示（開発モード時）✅