### PR TITLE
プルリクエストにブランチ名を表示する機能を追加

### DIFF
--- a/src/main/models/github.ts
+++ b/src/main/models/github.ts
@@ -56,4 +56,6 @@ export interface GitHubApiPullRequest {
   htmlUrl: string
   createdAt: string
   updatedAt: string
+  sourceBranch: string
+  targetBranch: string
 }

--- a/src/main/repositories/github/api-repository.ts
+++ b/src/main/repositories/github/api-repository.ts
@@ -47,6 +47,7 @@ interface GitHubPullRequestResponse {
   assignees: GitHubUserResponse[]
   requested_reviewers: GitHubUserResponse[]
   base: {
+    ref: string
     repo: {
       name: string
       html_url: string
@@ -56,6 +57,9 @@ interface GitHubPullRequestResponse {
         avatar_url: string
       }
     }
+  }
+  head: {
+    ref: string
   }
   [key: string]: unknown
 }
@@ -379,7 +383,9 @@ export class GitHubApiRepository {
           title: pull.title,
           htmlUrl: pull.html_url,
           createdAt: pull.created_at,
-          updatedAt: pull.updated_at
+          updatedAt: pull.updated_at,
+          sourceBranch: pull.head.ref,
+          targetBranch: pull.base.ref
         }
 
         return pullRequest

--- a/src/renderer/components/display/branch-arrow.tsx
+++ b/src/renderer/components/display/branch-arrow.tsx
@@ -1,0 +1,33 @@
+import TText from '@renderer/components/display/text'
+import { TRow } from '@renderer/components/layout/flex-box'
+import TTooltip from '@renderer/components/feedback/tooltip'
+import { Box } from '@mui/material'
+
+interface Props {
+  sourceBranch: string
+  targetBranch: string
+}
+
+export default function TBranchArrow({ sourceBranch, targetBranch }: Props) {
+  return (
+    <TRow gap={1} align="center">
+      <TTooltip title={sourceBranch}>
+        <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '45%' }}>
+          <TText variant="caption" bold whiteSpace="nowrap" overflow="hidden">
+            {sourceBranch}
+          </TText>
+        </Box>
+      </TTooltip>
+
+      <TText variant="caption">→</TText>
+
+      <TTooltip title={targetBranch}>
+        <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '45%' }}>
+          <TText variant="caption" bold whiteSpace="nowrap" overflow="hidden">
+            {targetBranch}
+          </TText>
+        </Box>
+      </TTooltip>
+    </TRow>
+  )
+}

--- a/src/renderer/components/feedback/tooltip.tsx
+++ b/src/renderer/components/feedback/tooltip.tsx
@@ -1,0 +1,28 @@
+import { Tooltip } from '@mui/material'
+import { ReactElement, ReactNode } from 'react'
+
+interface Props {
+  title: ReactNode
+  placement?:
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'bottom-end'
+    | 'bottom-start'
+    | 'left-end'
+    | 'left-start'
+    | 'right-end'
+    | 'right-start'
+    | 'top-end'
+    | 'top-start'
+  children: ReactElement
+}
+
+export default function TTooltip({ title, placement = 'top', children }: Props) {
+  return (
+    <Tooltip title={title} placement={placement} arrow>
+      {children}
+    </Tooltip>
+  )
+}

--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -14,6 +14,7 @@ import PendingIcon from '@renderer/components/display/icons/pending'
 import DismissedIcon from '@renderer/components/display/icons/dismissed'
 import QuestionIcon from '@renderer/components/display/icons/question'
 import TLink from '@renderer/components/navigation/link'
+import TBranchArrow from '@renderer/components/display/branch-arrow'
 
 type Props = {
   pullRequest: GitHubApiPullRequest
@@ -48,6 +49,10 @@ export default function GitHubPullRequestView({ pullRequest }: Props) {
             <TLink href={pullRequest.htmlUrl}>
               <TText>{pullRequest.title}</TText>
             </TLink>
+            <TBranchArrow
+              sourceBranch={pullRequest.sourceBranch}
+              targetBranch={pullRequest.targetBranch}
+            />
             <TRow gap={1}>
               <TText variant={'caption'}>{text.fromNow(pullRequest.createdAt)} created</TText>
               <TText variant={'caption'}>/</TText>

--- a/src/renderer/types/github.ts
+++ b/src/renderer/types/github.ts
@@ -57,4 +57,6 @@ export interface GitHubApiPullRequest {
   htmlUrl: string
   createdAt: string
   updatedAt: string
+  sourceBranch: string
+  targetBranch: string
 }


### PR DESCRIPTION
# 概要

プルリクエスト一覧画面でマージ元・マージ先のブランチ名を明確に表示する機能を実装

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/118

## 詳細

### 追加した機能
- GitHub APIからプルリクエストのブランチ情報（head.ref、base.ref）を取得
- プルリクエストカードにブランチ名を矢印形式（`source → target`）で表示
- 幅に応じた自動省略表示（CSSのtext-overflow: ellipsisを使用）
- Tooltipによるブランチ名全体の表示機能

### 変更したファイル
- **バックエンド**
  - `src/main/models/github.ts`: GitHubApiPullRequest型にsourceBranch、targetBranchフィールド追加
  - `src/main/repositories/github/api-repository.ts`: APIレスポンスからブランチ情報を取得する処理追加
- **フロントエンド**  
  - `src/renderer/types/github.ts`: フロントエンド側の型定義更新
  - `src/renderer/features/github/pull-request-view.tsx`: プルリクエストビューにブランチ表示を追加
  - `src/renderer/components/display/branch-arrow.tsx`: ブランチ名表示専用コンポーネント（新規）
  - `src/renderer/components/feedback/tooltip.tsx`: Tooltipコンポーネント（新規）

### 技術的な考慮点
- 固定長の文字数制限を廃止し、利用可能な幅に応じた動的な表示を実現
- 親要素の45%ずつをブランチ名に割り当て、画面幅を有効活用
- 既存のデザインシステムとの一貫性を保持