### PR TITLE
コピー＆ペースト機能を修正

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -96,7 +96,7 @@ function createWindow(): void {
 
 function setupApplicationMenu(): void {
   if (process.platform === 'darwin') {
-    // macOS requires a menu bar, so create a minimal one with only app menu
+    // macOS requires a menu bar, so create with app menu and edit menu
     const template: Electron.MenuItemConstructorOptions[] = [
       {
         label: app.name,
@@ -114,14 +114,91 @@ function setupApplicationMenu(): void {
             }
           }
         ]
+      },
+      {
+        label: 'Edit',
+        submenu: [
+          {
+            label: 'Undo',
+            accelerator: 'Command+Z',
+            role: 'undo'
+          },
+          {
+            label: 'Redo',
+            accelerator: 'Command+Shift+Z',
+            role: 'redo'
+          },
+          { type: 'separator' },
+          {
+            label: 'Cut',
+            accelerator: 'Command+X',
+            role: 'cut'
+          },
+          {
+            label: 'Copy',
+            accelerator: 'Command+C',
+            role: 'copy'
+          },
+          {
+            label: 'Paste',
+            accelerator: 'Command+V',
+            role: 'paste'
+          },
+          {
+            label: 'Select All',
+            accelerator: 'Command+A',
+            role: 'selectAll'
+          }
+        ]
       }
     ]
 
     const menu = Menu.buildFromTemplate(template)
     Menu.setApplicationMenu(menu)
   } else {
-    // Windows and Linux - remove menu completely
-    Menu.setApplicationMenu(null)
+    // Windows and Linux - create minimal menu for keyboard shortcuts
+    // Menu bar will be hidden due to autoHideMenuBar: true
+    const template: Electron.MenuItemConstructorOptions[] = [
+      {
+        label: 'Edit',
+        submenu: [
+          {
+            label: 'Undo',
+            accelerator: 'Ctrl+Z',
+            role: 'undo'
+          },
+          {
+            label: 'Redo',
+            accelerator: 'Ctrl+Shift+Z',
+            role: 'redo'
+          },
+          { type: 'separator' },
+          {
+            label: 'Cut',
+            accelerator: 'Ctrl+X',
+            role: 'cut'
+          },
+          {
+            label: 'Copy',
+            accelerator: 'Ctrl+C',
+            role: 'copy'
+          },
+          {
+            label: 'Paste',
+            accelerator: 'Ctrl+V',
+            role: 'paste'
+          },
+          {
+            label: 'Select All',
+            accelerator: 'Ctrl+A',
+            role: 'selectAll'
+          }
+        ]
+      }
+    ]
+
+    const menu = Menu.buildFromTemplate(template)
+    Menu.setApplicationMenu(menu)
   }
 }
 


### PR DESCRIPTION
# 概要

アプリケーション内でコピー＆ペースト機能が動作しない問題を修正

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/120

## 詳細

### 問題の原因
- ElectronアプリケーションでEditメニューが定義されていなかったため、標準的なキーボードショートカットが無効になっていた

### 修正内容
- **Editメニューの追加**
  - `src/main/index.ts`の`setupApplicationMenu`関数を修正
  - macOS用とWindows/Linux用の両プラットフォームに対応

- **実装した編集機能**
  - Undo (Cmd/Ctrl+Z)
  - Redo (Cmd/Ctrl+Shift+Z)
  - Cut (Cmd/Ctrl+X)
  - Copy (Cmd/Ctrl+C)
  - Paste (Cmd/Ctrl+V)
  - Select All (Cmd/Ctrl+A)

### 技術的な詳細
- Electronの`role`属性を使用して標準的な編集機能を実装
- Windows/Linuxでは`autoHideMenuBar: true`によりメニューバーは非表示のまま、キーボードショートカットのみ有効化
- プラットフォームごとに適切なアクセラレーターキー（Command vs Ctrl）を設定

### テスト確認項目
- ✅ GitHubのPersonal Access Token入力欄でペースト動作確認
- ✅ 各種テキストフィールドでコピー＆ペースト機能の動作確認
- ✅ TypeScriptの型チェック成功
- ✅ ESLintとPrettierのチェック成功