### PR TITLE
長いブランチ名による表示崩れを修正

### DIFF
--- a/src/renderer/components/display/branch-arrow.tsx
+++ b/src/renderer/components/display/branch-arrow.tsx
@@ -10,20 +10,38 @@ interface Props {
 
 export default function TBranchArrow({ sourceBranch, targetBranch }: Props) {
   return (
-    <TRow gap={1} align="center">
+    <TRow gap={1} align="center" fullWidth overflow="hidden">
       <TTooltip title={sourceBranch}>
-        <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '45%' }}>
-          <TText variant="caption" bold whiteSpace="nowrap" overflow="hidden">
+        <Box
+          sx={{
+            flex: '1 1 0',
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          <TText variant="caption" bold>
             {sourceBranch}
           </TText>
         </Box>
       </TTooltip>
 
-      <TText variant="caption">→</TText>
+      <Box sx={{ flexShrink: 0 }}>
+        <TText variant="caption">→</TText>
+      </Box>
 
       <TTooltip title={targetBranch}>
-        <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '45%' }}>
-          <TText variant="caption" bold whiteSpace="nowrap" overflow="hidden">
+        <Box
+          sx={{
+            flex: '1 1 0',
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          <TText variant="caption" bold>
             {targetBranch}
           </TText>
         </Box>


### PR DESCRIPTION
# 概要

長いブランチ名がプルリクエスト一覧で表示崩れを起こす問題を修正

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/123

## 詳細

- TBranchArrowコンポーネントのFlexboxレイアウトを改善
- 各ブランチ名のBoxに`flex: '1 1 0'`と`minWidth: 0`を設定し、適切な省略表示を実現
- 矢印アイコンを`flexShrink: 0`で固定幅に設定
- 親コンテナに`fullWidth`と`overflow: hidden`を追加し、レイアウトの制約を明確化