### PR TITLE
長いブランチ名の表示を改善

### DIFF
--- a/src/renderer/components/display/branch-arrow.tsx
+++ b/src/renderer/components/display/branch-arrow.tsx
@@ -1,7 +1,7 @@
 import TText from '@renderer/components/display/text'
-import { TRow } from '@renderer/components/layout/flex-box'
 import TTooltip from '@renderer/components/feedback/tooltip'
-import { Box } from '@mui/material'
+import TGrid from '@renderer/components/layout/grid'
+import ArrowForwardIcon from '@renderer/components/display/icons/arrow-forward'
 
 interface Props {
   sourceBranch: string
@@ -10,24 +10,20 @@ interface Props {
 
 export default function TBranchArrow({ sourceBranch, targetBranch }: Props) {
   return (
-    <TRow gap={1} align="center">
+    <TGrid columns={['1fr', '16px', '1fr']} columnGap={1} alignItems="center">
       <TTooltip title={sourceBranch}>
-        <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '45%' }}>
-          <TText variant="caption" bold whiteSpace="nowrap" overflow="hidden">
-            {sourceBranch}
-          </TText>
-        </Box>
+        <TText variant="caption" bold whiteSpace="nowrap" overflow="hidden">
+          {sourceBranch}
+        </TText>
       </TTooltip>
 
-      <TText variant="caption">→</TText>
+      <ArrowForwardIcon size={16} />
 
       <TTooltip title={targetBranch}>
-        <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '45%' }}>
-          <TText variant="caption" bold whiteSpace="nowrap" overflow="hidden">
-            {targetBranch}
-          </TText>
-        </Box>
+        <TText variant="caption" bold whiteSpace="nowrap" overflow="hidden">
+          {targetBranch}
+        </TText>
       </TTooltip>
-    </TRow>
+    </TGrid>
   )
 }

--- a/src/renderer/components/display/icons/arrow-forward.tsx
+++ b/src/renderer/components/display/icons/arrow-forward.tsx
@@ -1,0 +1,7 @@
+import { type IconProps, useIconColor } from './types'
+import { IoArrowForward } from 'react-icons/io5'
+
+export default function ArrowForwardIcon({ size = 24, color }: IconProps) {
+  const iconColor = useIconColor(color)
+  return <IoArrowForward size={size} color={iconColor} />
+}


### PR DESCRIPTION
# 概要

長いブランチ名のオーバーフロー処理を改善し、矢印をアイコン化することでUIの一貫性を向上

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/123

## 詳細

- テキストの矢印「→」を専用のArrowForwardIconコンポーネントに置き換え
- FlexBoxからGridレイアウトに変更し、固定幅の矢印領域を確保
- 不要なBoxラッパーを削除してコンポーネント構造を簡素化
- ブランチ名が長い場合でも適切にテキストがトランケートされるように改善