### PR TITLE
プルリクエストの自動リロードまでの残り時間を表示するプログレスバーを追加

### DIFF
--- a/src/renderer/components/feedback/linear-progress.tsx
+++ b/src/renderer/components/feedback/linear-progress.tsx
@@ -1,0 +1,23 @@
+import LinearProgress from '@mui/material/LinearProgress'
+import Box from '@mui/material/Box'
+
+interface Props {
+  value: number
+  width?: number
+  height?: number
+}
+
+export default function TLinearProgress({ value, width = 40, height = 3 }: Props) {
+  return (
+    <Box sx={{ width, height }}>
+      <LinearProgress
+        variant="determinate"
+        value={value}
+        sx={{
+          height,
+          borderRadius: height / 2
+        }}
+      />
+    </Box>
+  )
+}


### PR DESCRIPTION
# 概要

プルリクエスト画面のリロードボタン下に、自動リロードまでの残り時間を可視化する極小プログレスバーを追加。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/113

## 詳細

- `TLinearProgress` コンポーネントを新規作成（MUI LinearProgressをラップ）
  - 幅40px、高さ3pxのデフォルトサイズ
  - 角丸を適用したシンプルなデザイン
- プルリクエストパネルに自動リロードタイマー機能を追加
  - 1秒ごとにプログレスバーを更新（カウントダウン形式: 100%→0%）
  - 5分経過で自動リロード実行＆タイマーリセット
  - 手動リロード時もタイマーをリセット