### PR TITLE
プルリクエスト一覧の最終更新日時を相対時間表示に変更

### DIFF
--- a/src/renderer/features/github/pull-requests-panel.tsx
+++ b/src/renderer/features/github/pull-requests-panel.tsx
@@ -160,9 +160,7 @@ export default function GitHubPullRequestsPanel(props: Props) {
           <GitHubIcon />
           <TText>Open Pull Requests</TText>
           {lastFetchedAt && (
-            <TText variant="caption">
-              (Last updated: {text.formatDateTime(lastFetchedAt) ?? ''})
-            </TText>
+            <TText variant="caption">(Last updated: {text.fromNow(lastFetchedAt) ?? ''})</TText>
           )}
         </TRow>
         <TRow align="center">


### PR DESCRIPTION
# 概要

プルリクエスト一覧パネルの最終更新日時の表示形式を、絶対時間から相対時間（「5分前」など）に変更

## 対応Issue

なし

## 詳細

- `GitHubPullRequestsPanel` の最終更新日時表示を `text.formatDateTime()` から `text.fromNow()` に変更
- これにより「Last updated: 2024/01/13 10:00」のような表示が「Last updated: 5 minutes ago」のような相対時間表示になる