### PR TITLE
プルリクエスト一覧のソート機能を追加

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -381,6 +381,32 @@ app.whenReady().then(async () => {
     }
   })
 
+  // Pull Requests Settings IPC handlers
+  ipcMain.handle('settings:pullRequests:get', async () => {
+    try {
+      const store = getStore()
+      const settings = store.get('settings.pullRequests')
+      return { success: true, data: settings }
+    } catch (error) {
+      console.error('Failed to get pull requests settings:', error)
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+    }
+  })
+
+  ipcMain.handle(
+    'settings:pullRequests:set',
+    async (_, sortBy: 'createdAt' | 'updatedAt' | 'author', sortOrder: 'asc' | 'desc') => {
+      try {
+        const store = getStore()
+        store.set('settings.pullRequests', { sortBy, sortOrder })
+        return { success: true }
+      } catch (error) {
+        console.error('Failed to set pull requests settings:', error)
+        return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+      }
+    }
+  )
+
   // Debug Store IPC handlers (開発モードのみ)
   if (is.dev) {
     // electron-storeの全データを取得

--- a/src/main/models/store/settings/github.ts
+++ b/src/main/models/store/settings/github.ts
@@ -1,4 +1,5 @@
 import type { WindowState } from '../window'
+import type { StoreSettingsPullRequests } from './pull-requests'
 import type { StoreSettingsTheme } from './theme'
 
 /**
@@ -47,6 +48,7 @@ export interface StoreSchema {
   settings: {
     github: StoreSettingsGitHub
     theme: StoreSettingsTheme
+    pullRequests: StoreSettingsPullRequests
   }
   window?: WindowState
 }

--- a/src/main/models/store/settings/pull-requests.ts
+++ b/src/main/models/store/settings/pull-requests.ts
@@ -1,0 +1,17 @@
+/**
+ * ソートキーの定義
+ */
+export type SortKey = 'createdAt' | 'updatedAt' | 'author'
+
+/**
+ * ソート順序の定義
+ */
+export type SortOrder = 'asc' | 'desc'
+
+/**
+ * electron-storeで管理するプルリクエスト設定
+ */
+export interface StoreSettingsPullRequests {
+  sortBy: SortKey
+  sortOrder: SortOrder
+}

--- a/src/main/store/index.ts
+++ b/src/main/store/index.ts
@@ -25,6 +25,10 @@ export async function initializeStore(): Promise<Store<StoreSchema>> {
         },
         theme: {
           mode: 'system' // デフォルトはシステム連動
+        },
+        pullRequests: {
+          sortBy: 'updatedAt',
+          sortOrder: 'desc'
         }
       }
     }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -29,6 +29,24 @@ interface GitHubAPI {
   }>
 }
 
+type SortKey = 'createdAt' | 'updatedAt' | 'author'
+type SortOrder = 'asc' | 'desc'
+
+interface SettingsPullRequestsAPI {
+  get: () => Promise<{
+    success: boolean
+    data?: { sortBy: SortKey; sortOrder: SortOrder }
+    error?: string
+  }>
+  set: (
+    sortBy: SortKey,
+    sortOrder: SortOrder
+  ) => Promise<{
+    success: boolean
+    error?: string
+  }>
+}
+
 interface SettingsGitHubAPI {
   addAccount: (personalAccessToken: string) => Promise<{
     success: boolean
@@ -98,6 +116,7 @@ interface API {
   github: GitHubAPI
   settings: {
     github: SettingsGitHubAPI
+    pullRequests: SettingsPullRequestsAPI
   }
   app: AppAPI
   theme: ThemeAPI

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -41,6 +41,11 @@ const api = {
           ownerLogin,
           repositoryName
         )
+    },
+    pullRequests: {
+      get: () => ipcRenderer.invoke('settings:pullRequests:get'),
+      set: (sortBy: 'createdAt' | 'updatedAt' | 'author', sortOrder: 'asc' | 'desc') =>
+        ipcRenderer.invoke('settings:pullRequests:set', sortBy, sortOrder)
     }
   },
   app: {

--- a/src/renderer/features/github/pull-requests-panel.tsx
+++ b/src/renderer/features/github/pull-requests-panel.tsx
@@ -107,7 +107,7 @@ export default function GitHubPullRequestsPanel(props: Props) {
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const elapsedSecondsRef = useRef(0)
 
-  const { control, watch } = useForm<FilterFormData>({
+  const { control, watch, setValue } = useForm<FilterFormData>({
     defaultValues: {
       filterMyPRs: true,
       sortBy: 'updatedAt',
@@ -118,6 +118,7 @@ export default function GitHubPullRequestsPanel(props: Props) {
   const filterMyPRs = watch('filterMyPRs')
   const sortBy = watch('sortBy')
   const sortOrder = watch('sortOrder')
+  const [isSettingsLoaded, setIsSettingsLoaded] = useState(false)
 
   const sortKeyItems = [
     { value: 'createdAt', label: 'Created' },
@@ -152,6 +153,26 @@ export default function GitHubPullRequestsPanel(props: Props) {
       }
     })()
   }, [])
+
+  // ソート設定の読み込み
+  useEffect(() => {
+    ;(async () => {
+      const result = await window.api.settings.pullRequests.get()
+      if (result.success && result.data) {
+        setValue('sortBy', result.data.sortBy)
+        setValue('sortOrder', result.data.sortOrder)
+      }
+      setIsSettingsLoaded(true)
+    })()
+  }, [setValue])
+
+  // ソート設定の保存
+  useEffect(() => {
+    if (!isSettingsLoaded) return
+    ;(async () => {
+      await window.api.settings.pullRequests.set(sortBy, sortOrder)
+    })()
+  }, [sortBy, sortOrder, isSettingsLoaded])
 
   // エラーメッセージの表示
   useEffect(() => {


### PR DESCRIPTION
## 概要
プルリクエスト一覧の並び順を変更できる機能を追加

## 関連Issue
- fixes: https://github.com/pkshimizu/tell/issues/134

## 詳細
- ソートキー（作成日時・更新日時・作成者）を選択できるドロップダウンを追加
- ソート順序（昇順・降順）を選択できるドロップダウンを追加
- デフォルトは更新日時の降順
- ソート設定をelectron-storeに保存し、アプリ再起動時に前回の設定が維持されるようにした