### PR TITLE
プルリクエスト一覧にCI/CDチェックステータスを表示

### DIFF
--- a/src/main/models/github.ts
+++ b/src/main/models/github.ts
@@ -45,6 +45,31 @@ export interface GitHubApiPullRequestReviewer {
 
 export type GitHubPullRequestState = 'open' | 'closed'
 
+export type GitHubApiCheckStatusState = 'success' | 'failure' | 'pending' | 'in_progress'
+
+export type GitHubApiCheckRunStatus = 'queued' | 'in_progress' | 'completed'
+
+export type GitHubApiCheckRunConclusion =
+  | 'success'
+  | 'failure'
+  | 'neutral'
+  | 'cancelled'
+  | 'skipped'
+  | 'timed_out'
+  | 'action_required'
+  | null
+
+export interface GitHubApiCheckRun {
+  name: string
+  status: GitHubApiCheckRunStatus
+  conclusion: GitHubApiCheckRunConclusion
+}
+
+export interface GitHubApiStatusChecks {
+  state: GitHubApiCheckStatusState
+  checks: GitHubApiCheckRun[]
+}
+
 export interface GitHubApiPullRequest {
   id: string
   owner: GitHubApiOwner
@@ -58,4 +83,5 @@ export interface GitHubApiPullRequest {
   updatedAt: string
   sourceBranch: string
   targetBranch: string
+  statusChecks: GitHubApiStatusChecks | null
 }

--- a/src/renderer/components/display/icons/close.tsx
+++ b/src/renderer/components/display/icons/close.tsx
@@ -1,0 +1,7 @@
+import { IoCloseCircleOutline } from 'react-icons/io5'
+import { type IconProps, useIconColor } from './types'
+
+export default function CloseIcon({ size = 24, color }: IconProps) {
+  const iconColor = useIconColor(color)
+  return <IoCloseCircleOutline size={size} color={iconColor} />
+}

--- a/src/renderer/components/display/icons/loading.tsx
+++ b/src/renderer/components/display/icons/loading.tsx
@@ -1,0 +1,22 @@
+import { IoSyncOutline } from 'react-icons/io5'
+import { type IconProps, useIconColor } from './types'
+import { keyframes } from '@emotion/react'
+import styled from '@emotion/styled'
+
+const spin = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+const SpinningIcon = styled(IoSyncOutline)`
+  animation: ${spin} 1s linear infinite;
+`
+
+export default function LoadingIcon({ size = 24, color }: IconProps) {
+  const iconColor = useIconColor(color)
+  return <SpinningIcon size={size} color={iconColor} />
+}

--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -5,7 +5,11 @@ import CheckIcon from '@renderer/components/display/icons/check'
 import TGridItem from '@renderer/components/layout/grid-item'
 import TAvatar from '@renderer/components/display/avatar'
 import TBox from '@renderer/components/display/box'
-import { GitHubApiPullRequest, GitHubApiPullRequestReviewStatus } from '@renderer/types/github'
+import {
+  GitHubApiPullRequest,
+  GitHubApiPullRequestReviewStatus,
+  GitHubApiCheckRun
+} from '@renderer/types/github'
 import useText from '@renderer/hooks/text'
 import TGridContents from '@renderer/components/layout/grid-contents'
 import CommentIcon from '@renderer/components/display/icons/comment'
@@ -13,6 +17,8 @@ import AttentionIcon from '@renderer/components/display/icons/attention'
 import PendingIcon from '@renderer/components/display/icons/pending'
 import DismissedIcon from '@renderer/components/display/icons/dismissed'
 import QuestionIcon from '@renderer/components/display/icons/question'
+import CloseIcon from '@renderer/components/display/icons/close'
+import LoadingIcon from '@renderer/components/display/icons/loading'
 import TLink from '@renderer/components/navigation/link'
 import TBranchArrow from '@renderer/components/display/branch-arrow'
 
@@ -39,6 +45,22 @@ function ReviewStatusIcon({ status }: { status: GitHubApiPullRequestReviewStatus
   return <QuestionIcon />
 }
 
+function CheckRunStatusIcon({ check }: { check: GitHubApiCheckRun }) {
+  if (check.status === 'in_progress' || check.status === 'queued') {
+    return <LoadingIcon size={14} color={'info'} />
+  }
+  if (check.conclusion === 'success') {
+    return <CheckIcon size={14} color={'success'} />
+  }
+  if (check.conclusion === 'failure') {
+    return <CloseIcon size={14} color={'error'} />
+  }
+  if (check.conclusion === 'skipped' || check.conclusion === 'neutral') {
+    return <DismissedIcon size={14} />
+  }
+  return <PendingIcon size={14} color={'warning'} />
+}
+
 export default function GitHubPullRequestView({ pullRequest }: Props) {
   const text = useText()
   return (
@@ -53,6 +75,16 @@ export default function GitHubPullRequestView({ pullRequest }: Props) {
               sourceBranch={pullRequest.sourceBranch}
               targetBranch={pullRequest.targetBranch}
             />
+            {pullRequest.statusChecks && pullRequest.statusChecks.checks.length > 0 && (
+              <TRow gap={1} align={'center'}>
+                {pullRequest.statusChecks.checks.map((check, index) => (
+                  <TRow key={`${check.name}-${index}`} align={'center'} gap={0.5}>
+                    <CheckRunStatusIcon check={check} />
+                    <TText variant={'caption'}>{check.name}</TText>
+                  </TRow>
+                ))}
+              </TRow>
+            )}
             <TRow gap={1}>
               <TText variant={'caption'}>{text.fromNow(pullRequest.createdAt)} created</TText>
               <TText variant={'caption'}>/</TText>

--- a/src/renderer/types/github.ts
+++ b/src/renderer/types/github.ts
@@ -38,6 +38,31 @@ export type GitHubApiPullRequestReviewStatus =
   | 'pending'
   | 'dismissed'
 
+export type GitHubApiCheckStatusState = 'success' | 'failure' | 'pending' | 'in_progress'
+
+export type GitHubApiCheckRunStatus = 'queued' | 'in_progress' | 'completed'
+
+export type GitHubApiCheckRunConclusion =
+  | 'success'
+  | 'failure'
+  | 'neutral'
+  | 'cancelled'
+  | 'skipped'
+  | 'timed_out'
+  | 'action_required'
+  | null
+
+export interface GitHubApiCheckRun {
+  name: string
+  status: GitHubApiCheckRunStatus
+  conclusion: GitHubApiCheckRunConclusion
+}
+
+export interface GitHubApiStatusChecks {
+  state: GitHubApiCheckStatusState
+  checks: GitHubApiCheckRun[]
+}
+
 export interface GitHubApiPullRequestReviewer {
   name: string
   htmlUrl: string
@@ -59,4 +84,5 @@ export interface GitHubApiPullRequest {
   updatedAt: string
   sourceBranch: string
   targetBranch: string
+  statusChecks: GitHubApiStatusChecks | null
 }


### PR DESCRIPTION
## Summary
プルリクエスト一覧にGitHub ActionsなどのCI/CDチェック結果を表示する機能を追加

## Related Issue
- fixes: https://github.com/pkshimizu/tell/issues/135

## Details
- GitHub GraphQL APIの`statusCheckRollup`を使用してチェック情報を取得
- チェックの全体ステータス（成功/失敗/実行中/保留中）を判定
- 各チェックの名前と結果をアイコンで表示
  - 成功: 緑のチェックアイコン
  - 失敗: 赤の×アイコン
  - 実行中: 回転する同期アイコン
  - 保留中: 黄色の待機アイコン
- タイトル・ブランチ名の下に一行でチェック情報を表示