### PR TITLE
プルリクエストの更新時間に応じた色分け表示

### DIFF
--- a/src/renderer/components/display/text.tsx
+++ b/src/renderer/components/display/text.tsx
@@ -1,4 +1,6 @@
 import { Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import type { ThemeColor } from '@renderer/types/color'
 
 type Text = string | number | Text[]
 type Variant = 'caption' | 'body' | 'subtitle' | 'title' | 'headline'
@@ -12,6 +14,7 @@ interface Props {
   overflow?: 'hidden' | 'visible' | 'scroll' | 'auto'
   fullWidth?: boolean
   fullHeight?: boolean
+  color?: ThemeColor
   children: Text
 }
 
@@ -35,6 +38,9 @@ function typographyVariant(variant?: Variant) {
 }
 
 export default function TText(props: Props) {
+  const theme = useTheme()
+  const textColor = props.color ? theme.palette[props.color].main : undefined
+
   return (
     <Typography
       variant={typographyVariant(props.variant)}
@@ -46,7 +52,8 @@ export default function TText(props: Props) {
         overflow: props.overflow,
         textOverflow: 'ellipsis',
         width: props.fullWidth ? '100%' : undefined,
-        height: props.fullHeight ? '100%' : undefined
+        height: props.fullHeight ? '100%' : undefined,
+        color: textColor
       }}
     >
       {props.children}

--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -21,9 +21,28 @@ import CloseIcon from '@renderer/components/display/icons/close'
 import LoadingIcon from '@renderer/components/display/icons/loading'
 import TLink from '@renderer/components/navigation/link'
 import TBranchArrow from '@renderer/components/display/branch-arrow'
+import type { ThemeColor } from '@renderer/types/color'
 
 type Props = {
   pullRequest: GitHubApiPullRequest
+}
+
+function getUpdateTimeColor(updatedAt: string): ThemeColor {
+  const now = new Date()
+  const updated = new Date(updatedAt)
+  const diffMs = now.getTime() - updated.getTime()
+  const diffMinutes = diffMs / (1000 * 60)
+
+  if (diffMinutes <= 10) {
+    return 'success'
+  }
+  if (diffMinutes <= 4 * 60) {
+    return 'warning'
+  }
+  if (diffMinutes <= 24 * 60) {
+    return 'error'
+  }
+  return 'critical'
 }
 
 function ReviewStatusIcon({ status }: { status: GitHubApiPullRequestReviewStatus }) {
@@ -88,7 +107,9 @@ export default function GitHubPullRequestView({ pullRequest }: Props) {
             <TRow gap={1}>
               <TText variant={'caption'}>{text.fromNow(pullRequest.createdAt)} created</TText>
               <TText variant={'caption'}>/</TText>
-              <TText variant={'caption'}>{text.fromNow(pullRequest.updatedAt)} updated</TText>
+              <TText variant={'caption'} color={getUpdateTimeColor(pullRequest.updatedAt)}>
+                {text.fromNow(pullRequest.updatedAt)} updated
+              </TText>
             </TRow>
           </TColumn>
         </TGridItem>

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -4,9 +4,35 @@ import { createTheme, type Theme } from '@mui/material/styles'
 declare module '@mui/material/styles' {
   interface Palette {
     boxBackground: Palette['primary']
+    critical: Palette['primary']
   }
   interface PaletteOptions {
     boxBackground?: PaletteOptions['primary']
+    critical?: PaletteOptions['primary']
+  }
+}
+
+declare module '@mui/material/Chip' {
+  interface ChipPropsColorOverrides {
+    critical: true
+  }
+}
+
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    critical: true
+  }
+}
+
+declare module '@mui/material/IconButton' {
+  interface IconButtonPropsColorOverrides {
+    critical: true
+  }
+}
+
+declare module '@mui/material/AppBar' {
+  interface AppBarPropsColorOverrides {
+    critical: true
   }
 }
 
@@ -55,6 +81,9 @@ export const lightTheme: Theme = createTheme({
     boxBackground: {
       main: '#e3f2fd'
     },
+    critical: {
+      main: '#9c27b0'
+    },
     background: {
       default: '#fafafa',
       paper: '#ffffff'
@@ -93,6 +122,9 @@ export const darkTheme: Theme = createTheme({
     },
     boxBackground: {
       main: '#1e1e1e'
+    },
+    critical: {
+      main: '#ba68c8'
     },
     background: {
       default: '#121212',

--- a/src/renderer/types/color.ts
+++ b/src/renderer/types/color.ts
@@ -1,4 +1,8 @@
-export type ThemeColor = 'primary' | 'secondary' | 'error' | 'warning' | 'info' | 'success'
+// Material-UI コンポーネントで使用可能な標準色
+export type MuiColor = 'primary' | 'secondary' | 'error' | 'warning' | 'info' | 'success'
+
+// カスタムテーマカラー（critical などの拡張色を含む）
+export type ThemeColor = MuiColor | 'critical'
 
 export type BackgroundColor = 'boxBackground'
 


### PR DESCRIPTION
# 概要

プルリクエストの更新時間によって、更新時間の表示色を変えて識別しやすくする機能を追加

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/141

## 詳細

- 経過時間に応じた色分けルールを実装
  - 10分以内: 緑(success)
  - 4時間以内: 黄(warning)
  - 1日以内: 赤(error)
  - それ以上: 紫(critical)
- テーマに `critical` カラー（紫）を追加
- TText コンポーネントに `color` プロパティを追加し、テーマカラーでテキスト色を指定可能に
- Material-UI コンポーネント（Chip, Button, IconButton, AppBar）でも `critical` カラーを使用可能に