### PR TITLE
プルリクエスト更新時間の色分けしきい値を変更

### DIFF
--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -33,13 +33,13 @@ function getUpdateTimeColor(updatedAt: string): ThemeColor {
   const diffMs = now.getTime() - updated.getTime()
   const diffMinutes = diffMs / (1000 * 60)
 
-  if (diffMinutes <= 10) {
+  if (diffMinutes <= 60) {
     return 'success'
   }
-  if (diffMinutes <= 4 * 60) {
+  if (diffMinutes <= 24 * 60) {
     return 'warning'
   }
-  if (diffMinutes <= 24 * 60) {
+  if (diffMinutes <= 3 * 24 * 60) {
     return 'error'
   }
   return 'critical'


### PR DESCRIPTION
## 概要

プルリクエストの更新時間を表示する際の色分けしきい値を変更

## 関連Issue

- fixes: https://github.com/pkshimizu/tell/issues/143

## 詳細

- success（緑）: 10分以内 → 1時間以内に変更
- warning（黄）: 4時間以内 → 1日以内に変更
- error（赤）: 24時間以内 → 3日以内に変更
- critical（濃い赤）: それ以上（変更なし）