### PR TITLE
GitHub Personal Access Tokenの削除機能を追加

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -369,6 +369,17 @@ app.whenReady().then(async () => {
       }
     }
   )
+  ipcMain.handle('settings:github:deleteAccount', async (_, accountId: string) => {
+    try {
+      settingsService.deleteGitHubAccount(accountId)
+      return { success: true }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred'
+      }
+    }
+  })
   ipcMain.handle('github:getPullRequests', async (_, state: 'open' | 'closed') => {
     try {
       const pullRequests = await githubService.getPullRequests(state)

--- a/src/main/services/settings-service.ts
+++ b/src/main/services/settings-service.ts
@@ -191,6 +191,22 @@ export class SettingsService {
 
     return updatedAccount
   }
+
+  /**
+   * GitHubアカウントを削除する
+   * @param accountId - GitHubアカウントID (UUID)
+   * @throws Error - アカウントが見つからない場合
+   */
+  deleteGitHubAccount(accountId: string): void {
+    // storeからアカウント情報を取得
+    const existingAccount = githubStoreRepository.findAccountById(accountId)
+    if (!existingAccount) {
+      throw new Error(`GitHub account with id '${accountId}' not found`)
+    }
+
+    // アカウントを削除
+    githubStoreRepository.deleteAccount(accountId)
+  }
 }
 
 export const settingsService = new SettingsService()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -106,6 +106,10 @@ interface SettingsGitHubAPI {
     data?: GithubAccount
     error?: string
   }>
+  deleteAccount: (accountId: string) => Promise<{
+    success: boolean
+    error?: string
+  }>
 }
 
 interface AppAPI {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -44,7 +44,9 @@ const api = {
       getAllRegisteredRepositories: () =>
         ipcRenderer.invoke('settings:github:getAllRegisteredRepositories'),
       updateAccountToken: (accountId: string, personalAccessToken: string) =>
-        ipcRenderer.invoke('settings:github:updateAccountToken', accountId, personalAccessToken)
+        ipcRenderer.invoke('settings:github:updateAccountToken', accountId, personalAccessToken),
+      deleteAccount: (accountId: string) =>
+        ipcRenderer.invoke('settings:github:deleteAccount', accountId)
     },
     pullRequests: {
       get: () => ipcRenderer.invoke('settings:pullRequests:get'),

--- a/src/renderer/features/settings/github/account-delete-dialog.tsx
+++ b/src/renderer/features/settings/github/account-delete-dialog.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import TDialog from '@renderer/components/feedback/dialog'
+import TButton from '@renderer/components/form/button'
+import { TColumn, TRow } from '@renderer/components/layout/flex-box'
+import TText from '@renderer/components/display/text'
+import useMessage from '@renderer/hooks/message'
+import { GitHubAccount } from '@renderer/types/github'
+
+interface Props {
+  open: boolean
+  account: GitHubAccount | null
+  onClose: () => void
+  onDeleted?: () => void
+}
+
+export default function GitHubAccountDeleteDialog({ open, account, onClose, onDeleted }: Props) {
+  const message = useMessage()
+  const [processing, setProcessing] = useState(false)
+
+  const handleDelete = async () => {
+    if (!account) return
+
+    setProcessing(true)
+
+    try {
+      const result = await window.api.settings.github.deleteAccount(String(account.id))
+
+      if (result.success) {
+        message.setMessage('success', `Account ${account.login} has been deleted`)
+        onClose()
+        if (onDeleted) {
+          onDeleted()
+        }
+      } else {
+        message.setMessage('error', result.error || 'Failed to delete account')
+      }
+    } catch (error) {
+      message.setMessage(
+        'error',
+        error instanceof Error ? error.message : 'An unexpected error occurred'
+      )
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  return (
+    <TDialog
+      open={open}
+      title="Delete Account"
+      size="sm"
+      onClose={onClose}
+      actions={
+        <TRow gap={1}>
+          <TButton onClick={onClose} disabled={processing}>
+            Cancel
+          </TButton>
+          <TButton variant="contained" color="error" onClick={handleDelete} processing={processing}>
+            Delete
+          </TButton>
+        </TRow>
+      }
+    >
+      <TColumn gap={2}>
+        {account && (
+          <TColumn gap={1}>
+            <TText>Are you sure you want to delete the following account?</TText>
+            <TText bold>{account.login}</TText>
+            <TText variant="caption">
+              This will remove the account and all associated repository settings.
+            </TText>
+          </TColumn>
+        )}
+      </TColumn>
+    </TDialog>
+  )
+}

--- a/src/renderer/features/settings/github/account-table.tsx
+++ b/src/renderer/features/settings/github/account-table.tsx
@@ -10,12 +10,15 @@ import TButton from '@renderer/components/form/button'
 import TIconButton from '@renderer/components/form/icon-button'
 import GitHubRepositorySelectDialog from './repository-select-dialog'
 import GitHubAccountUpdateTokenDialog from './account-update-token-dialog'
+import GitHubAccountDeleteDialog from './account-delete-dialog'
 import GitHubIcon from '@renderer/components/display/icons/github'
 import CloseIcon from '@renderer/components/display/icons/close'
+import { IoTrash } from 'react-icons/io5'
 
 interface Props {
   accounts: GitHubAccount[]
   onAccountUpdated?: (account: GitHubAccount) => void
+  onAccountDeleted?: () => void
 }
 
 interface RegisteredRepository {
@@ -25,11 +28,19 @@ interface RegisteredRepository {
   repositoryHtmlUrl: string
 }
 
-export default function GitHubAccountTable({ accounts, onAccountUpdated }: Props) {
+export default function GitHubAccountTable({
+  accounts,
+  onAccountUpdated,
+  onAccountDeleted
+}: Props) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [updateTokenDialogOpen, setUpdateTokenDialogOpen] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [selectedAccountId, setSelectedAccountId] = useState<number | null>(null)
   const [selectedAccountForUpdate, setSelectedAccountForUpdate] = useState<GitHubAccount | null>(
+    null
+  )
+  const [selectedAccountForDelete, setSelectedAccountForDelete] = useState<GitHubAccount | null>(
     null
   )
   const [repositories, setRepositories] = useState<RegisteredRepository[]>([])
@@ -73,6 +84,23 @@ export default function GitHubAccountTable({ accounts, onAccountUpdated }: Props
     }
   }
 
+  const handleOpenDeleteDialog = (account: GitHubAccount) => {
+    setSelectedAccountForDelete(account)
+    setDeleteDialogOpen(true)
+  }
+
+  const handleCloseDeleteDialog = () => {
+    setDeleteDialogOpen(false)
+    setSelectedAccountForDelete(null)
+  }
+
+  const handleAccountDeleted = () => {
+    loadRepositories()
+    if (onAccountDeleted) {
+      onAccountDeleted()
+    }
+  }
+
   const getAccountRepositories = (accountId: number) => {
     return repositories.filter((repo) => repo.accountId === String(accountId))
   }
@@ -98,7 +126,7 @@ export default function GitHubAccountTable({ accounts, onAccountUpdated }: Props
         {accounts.map((account) => (
           <TColumn key={account.id} gap={1}>
             <TGrid
-              columns={['56px', '1fr', '160px', '120px', '120px']}
+              columns={['56px', '1fr', '160px', '120px', '120px', '40px']}
               gap={2}
               alignItems={'center'}
             >
@@ -119,6 +147,9 @@ export default function GitHubAccountTable({ accounts, onAccountUpdated }: Props
               </TColumn>
               <TButton onClick={() => handleOpenUpdateTokenDialog(account)}>Update Token</TButton>
               <TButton onClick={() => handleOpenDialog(account.id)}>Repositories</TButton>
+              <TIconButton onClick={() => handleOpenDeleteDialog(account)}>
+                <IoTrash size={20} />
+              </TIconButton>
             </TGrid>
             {getAccountRepositories(account.id).length > 0 && (
               <TColumn gap={0.5}>
@@ -160,6 +191,12 @@ export default function GitHubAccountTable({ accounts, onAccountUpdated }: Props
         account={selectedAccountForUpdate}
         onClose={handleCloseUpdateTokenDialog}
         onTokenUpdated={handleTokenUpdated}
+      />
+      <GitHubAccountDeleteDialog
+        open={deleteDialogOpen}
+        account={selectedAccountForDelete}
+        onClose={handleCloseDeleteDialog}
+        onDeleted={handleAccountDeleted}
       />
     </>
   )

--- a/src/renderer/routes/settings/github.tsx
+++ b/src/renderer/routes/settings/github.tsx
@@ -85,6 +85,14 @@ function RouteComponent() {
     )
   }
 
+  const handleAccountDeleted = async () => {
+    // アカウント一覧を再読み込み
+    const result = await window.api.settings.github.getAccounts()
+    if (result.success && result.data) {
+      setAccounts(result.data)
+    }
+  }
+
   return (
     <TColumn gap={2} fullWidth>
       <TText variant="title">GitHub Settings</TText>
@@ -93,7 +101,11 @@ function RouteComponent() {
         <TSelect name="reloadInterval" control={control} items={reloadIntervalItems} />
       </TRow>
       <GitHubAccountCreateForm onAccountAdded={handleAccountAdded} />
-      <GitHubAccountTable accounts={accounts} onAccountUpdated={handleAccountUpdated} />
+      <GitHubAccountTable
+        accounts={accounts}
+        onAccountUpdated={handleAccountUpdated}
+        onAccountDeleted={handleAccountDeleted}
+      />
     </TColumn>
   )
 }


### PR DESCRIPTION
# 概要

設定画面からGitHubアカウントを削除できる機能を追加

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/146

## 詳細

- 設定画面のGitHubアカウント一覧にゴミ箱アイコンの削除ボタンを追加
- 削除確認ダイアログ（account-delete-dialog.tsx）を新規作成
- `settings-service.ts`に`deleteGitHubAccount`メソッドを追加
- `settings:github:deleteAccount` IPCハンドラーを追加
- 削除後はアカウント一覧を自動的に更新