### PR TITLE
リリースワークフローのトリガーをpublishedに変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## 概要
リリースワークフローのトリガー条件をcreatedからpublishedに変更し、Draftリリース公開時にもビルドが実行されるように修正

## 関連Issue
- fixes: https://github.com/pkshimizu/tell/issues/153

## 詳細
- `.github/workflows/release.yml`のトリガー条件を`types: [created]`から`types: [published]`に変更
- `published`イベントは新規リリース作成時とDraft公開時の両方で発生するため、すべてのリリースパターンに対応可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)