### PR TITLE
プルリクエストのチェック一覧が複数行に折り返されるよう修正

### DIFF
--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -95,7 +95,7 @@ export default function GitHubPullRequestView({ pullRequest }: Props) {
               targetBranch={pullRequest.targetBranch}
             />
             {pullRequest.statusChecks && pullRequest.statusChecks.checks.length > 0 && (
-              <TRow gap={1} align={'center'}>
+              <TRow rowGap={0.5} columnGap={1} align={'center'} wrap={'wrap'}>
                 {pullRequest.statusChecks.checks.map((check, index) => (
                   <TRow key={`${check.name}-${index}`} align={'center'} gap={0.5}>
                     <CheckRunStatusIcon check={check} />


### PR DESCRIPTION
## Summary
プルリクエストのチェック件数が増えた際にデザインが崩れる問題を修正

## Related Issue
- fixes: https://github.com/pkshimizu/tell/issues/157

## Details
- プルリクエスト画面のチェック一覧表示にwrap属性を追加
- チェック件数が増えた場合に複数行に折り返されるようレイアウトを改善
- rowGapとcolumnGapを分けて設定し、折り返し時の間隔を適切に調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)