### PR TITLE
プルリクエストのタイトルの前にプルリクエスト番号を表示する

### DIFF
--- a/src/main/models/github.ts
+++ b/src/main/models/github.ts
@@ -72,6 +72,7 @@ export interface GitHubApiStatusChecks {
 
 export interface GitHubApiPullRequest {
   id: string
+  number: number
   owner: GitHubApiOwner
   repository: GitHubApiRepository
   author: GitHubApiPullRequestAuthor

--- a/src/main/repositories/github/api-repository.ts
+++ b/src/main/repositories/github/api-repository.ts
@@ -591,6 +591,7 @@ export class GitHubApiRepository {
 
         const pullRequest: GitHubApiPullRequest = {
           id: pr.id,
+          number: pr.number,
           owner: {
             login: repo.owner.login,
             htmlUrl: repo.owner.url,

--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -88,7 +88,7 @@ export default function GitHubPullRequestView({ pullRequest }: Props) {
         <TGridItem align={'center'}>
           <TColumn>
             <TLink href={pullRequest.htmlUrl}>
-              <TText>{pullRequest.title}</TText>
+              <TText>{`#${pullRequest.number} ${pullRequest.title}`}</TText>
             </TLink>
             <TBranchArrow
               sourceBranch={pullRequest.sourceBranch}

--- a/src/renderer/types/github.ts
+++ b/src/renderer/types/github.ts
@@ -73,6 +73,7 @@ export interface GitHubApiPullRequestReviewer {
 
 export interface GitHubApiPullRequest {
   id: string
+  number: number
   owner: GitHubOwner
   repository: GitHubRepository
   author: GitHubApiPullRequestAuthor


### PR DESCRIPTION
# 概要

プルリクエスト一覧でタイトルの前にプルリクエスト番号を表示し、識別性を向上させる。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/162

## 詳細

- `GitHubApiPullRequest` 型に `number` フィールドを追加（main/renderer両方）
- GraphQLレスポンスの `pr.number` をマッピングに追加
- プルリクエストのタイトル表示を `#{番号} {タイトル}` 形式に変更