### PR TITLE
プルリクエストのURLをコピーするアイコンボタンを追加

### DIFF
--- a/src/renderer/components/display/icons/copy.tsx
+++ b/src/renderer/components/display/icons/copy.tsx
@@ -1,0 +1,7 @@
+import { IoCopyOutline } from 'react-icons/io5'
+import { type IconProps, useIconColor } from './types'
+
+export default function CopyIcon({ size = 24, color }: IconProps) {
+  const iconColor = useIconColor(color)
+  return <IoCopyOutline size={size} color={iconColor} />
+}

--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -21,6 +21,8 @@ import CloseIcon from '@renderer/components/display/icons/close'
 import LoadingIcon from '@renderer/components/display/icons/loading'
 import TLink from '@renderer/components/navigation/link'
 import TBranchArrow from '@renderer/components/display/branch-arrow'
+import TIconButton from '@renderer/components/form/icon-button'
+import CopyIcon from '@renderer/components/display/icons/copy'
 import type { ThemeColor } from '@renderer/types/color'
 
 type Props = {
@@ -87,9 +89,18 @@ export default function GitHubPullRequestView({ pullRequest }: Props) {
       <TGrid columns={['1fr', '160px', '240px']} gap={1}>
         <TGridItem align={'center'}>
           <TColumn>
-            <TLink href={pullRequest.htmlUrl}>
-              <TText>{`#${pullRequest.number} ${pullRequest.title}`}</TText>
-            </TLink>
+            <TRow align={'center'} gap={0.5}>
+              <TLink href={pullRequest.htmlUrl}>
+                <TText>{`#${pullRequest.number} ${pullRequest.title}`}</TText>
+              </TLink>
+              <TIconButton
+                onClick={() => {
+                  navigator.clipboard.writeText(pullRequest.htmlUrl)
+                }}
+              >
+                <CopyIcon size={16} />
+              </TIconButton>
+            </TRow>
             <TBranchArrow
               sourceBranch={pullRequest.sourceBranch}
               targetBranch={pullRequest.targetBranch}


### PR DESCRIPTION
# 概要

プルリクエスト一覧でURLをワンクリックでクリップボードにコピーできるアイコンボタンを追加する。

## 対応Issue

- fixes: https://github.com/pkshimizu/tell/issues/164

## 詳細

- コピーアイコンコンポーネント (`CopyIcon`) を新規作成
- プルリクエストのタイトル横にコピーアイコンボタンを配置
- クリック時に `navigator.clipboard.writeText()` でPRのURLをクリップボードにコピー