### PR TITLE
プルリクエストのタイトルが長い場合のレイアウト崩れを修正

### DIFF
--- a/src/renderer/components/display/icons/copy.tsx
+++ b/src/renderer/components/display/icons/copy.tsx
@@ -1,0 +1,7 @@
+import { IoCopyOutline } from 'react-icons/io5'
+import { type IconProps, useIconColor } from './types'
+
+export default function CopyIcon({ size = 24, color }: IconProps) {
+  const iconColor = useIconColor(color)
+  return <IoCopyOutline size={size} color={iconColor} />
+}

--- a/src/renderer/components/display/icons/copy.tsx
+++ b/src/renderer/components/display/icons/copy.tsx
@@ -1,7 +1,0 @@
-import { IoCopyOutline } from 'react-icons/io5'
-import { type IconProps, useIconColor } from './types'
-
-export default function CopyIcon({ size = 24, color }: IconProps) {
-  const iconColor = useIconColor(color)
-  return <IoCopyOutline size={size} color={iconColor} />
-}

--- a/src/renderer/components/navigation/link.tsx
+++ b/src/renderer/components/navigation/link.tsx
@@ -16,7 +16,8 @@ export default function TLink({ href, children }: Props) {
         color: 'black.main',
         textDecorationColor: 'inherit',
         textDecoration: 'none',
-        cursor: 'pointer'
+        cursor: 'pointer',
+        overflowWrap: 'anywhere'
       }}
     >
       {children}

--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -21,6 +21,8 @@ import CloseIcon from '@renderer/components/display/icons/close'
 import LoadingIcon from '@renderer/components/display/icons/loading'
 import TLink from '@renderer/components/navigation/link'
 import TBranchArrow from '@renderer/components/display/branch-arrow'
+import TIconButton from '@renderer/components/form/icon-button'
+import CopyIcon from '@renderer/components/display/icons/copy'
 import type { ThemeColor } from '@renderer/types/color'
 
 type Props = {
@@ -87,9 +89,18 @@ export default function GitHubPullRequestView({ pullRequest }: Props) {
       <TGrid columns={['minmax(0, 1fr)', '160px', '240px']} gap={1}>
         <TGridItem align={'center'}>
           <TColumn>
-            <TLink href={pullRequest.htmlUrl}>
-              <TText>{`#${pullRequest.number} ${pullRequest.title}`}</TText>
-            </TLink>
+            <TRow align={'center'} gap={0.5}>
+              <TLink href={pullRequest.htmlUrl}>
+                <TText>{`#${pullRequest.number} ${pullRequest.title}`}</TText>
+              </TLink>
+              <TIconButton
+                onClick={() => {
+                  navigator.clipboard.writeText(pullRequest.htmlUrl)
+                }}
+              >
+                <CopyIcon size={16} />
+              </TIconButton>
+            </TRow>
             <TBranchArrow
               sourceBranch={pullRequest.sourceBranch}
               targetBranch={pullRequest.targetBranch}

--- a/src/renderer/features/github/pull-request-view.tsx
+++ b/src/renderer/features/github/pull-request-view.tsx
@@ -21,8 +21,6 @@ import CloseIcon from '@renderer/components/display/icons/close'
 import LoadingIcon from '@renderer/components/display/icons/loading'
 import TLink from '@renderer/components/navigation/link'
 import TBranchArrow from '@renderer/components/display/branch-arrow'
-import TIconButton from '@renderer/components/form/icon-button'
-import CopyIcon from '@renderer/components/display/icons/copy'
 import type { ThemeColor } from '@renderer/types/color'
 
 type Props = {
@@ -86,21 +84,12 @@ export default function GitHubPullRequestView({ pullRequest }: Props) {
   const text = useText()
   return (
     <TBox backgroundColor={'boxBackground'} padding={2}>
-      <TGrid columns={['1fr', '160px', '240px']} gap={1}>
+      <TGrid columns={['minmax(0, 1fr)', '160px', '240px']} gap={1}>
         <TGridItem align={'center'}>
           <TColumn>
-            <TRow align={'center'} gap={0.5}>
-              <TLink href={pullRequest.htmlUrl}>
-                <TText>{`#${pullRequest.number} ${pullRequest.title}`}</TText>
-              </TLink>
-              <TIconButton
-                onClick={() => {
-                  navigator.clipboard.writeText(pullRequest.htmlUrl)
-                }}
-              >
-                <CopyIcon size={16} />
-              </TIconButton>
-            </TRow>
+            <TLink href={pullRequest.htmlUrl}>
+              <TText>{`#${pullRequest.number} ${pullRequest.title}`}</TText>
+            </TLink>
             <TBranchArrow
               sourceBranch={pullRequest.sourceBranch}
               targetBranch={pullRequest.targetBranch}


### PR DESCRIPTION
# 概要

プルリクエストのタイトルが長い場合にウィンドウ幅を狭くするとレイアウトが崩れる問題を修正

## 詳細

- CSS Gridの1列目を `1fr` から `minmax(0, 1fr)` に変更し、コンテンツサイズ以下に縮小可能にした
- TLinkコンポーネントに `overflowWrap: 'anywhere'` を追加し、URLパスなどの長い文字列が適切に折り返されるようにした
- 不要になったコピーアイコンボタンとCopyIconコンポーネントを削除