### PR TITLE
macOSリリースのコード署名と公証に対応する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate macOS signing secrets
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          missing=0
+          for secret_name in CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "${!secret_name}" ]; then
+              echo "::error::$secret_name is not configured"
+              missing=1
+            fi
+          done
+          exit "$missing"
+
       - name: Build, sign, and notarize macOS app
-        run: npm run build:mac
+        run: npm run build:mac -- --config electron-builder.release.yml
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build macOS app
+      - name: Build, sign, and notarize macOS app
         run: npm run build:mac
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Verify macOS signature and notarization
+        run: |
+          APP_PATH="dist/mac-universal/tell.app"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+          spctl --assess --verbose --type exec "$APP_PATH"
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,18 +99,6 @@ jobs:
     needs: check-version
     runs-on: macos-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Validate macOS signing secrets
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -127,6 +115,18 @@ jobs:
             fi
           done
           exit "$missing"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build, sign, and notarize macOS app
         run: npm run build:mac -- --config electron-builder.release.yml

--- a/electron-builder.release.yml
+++ b/electron-builder.release.yml
@@ -1,6 +1,7 @@
 extends: electron-builder.yml
 mac:
   forceCodeSigning: true
+  identity: ''
   hardenedRuntime: true
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist

--- a/electron-builder.release.yml
+++ b/electron-builder.release.yml
@@ -1,0 +1,7 @@
+extends: electron-builder.yml
+mac:
+  forceCodeSigning: true
+  hardenedRuntime: true
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  notarize: true

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -22,18 +22,20 @@ portable:
   artifactName: ${name}-${version}-win.${ext}
 mac:
   icon: build/icon.png
+  forceCodeSigning: true
   target:
     - target: zip
       arch:
         - universal
+  hardenedRuntime: true
+  entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
-  identity: null
+  notarize: true
 npmRebuild: false
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -22,20 +22,16 @@ portable:
   artifactName: ${name}-${version}-win.${ext}
 mac:
   icon: build/icon.png
-  forceCodeSigning: true
   target:
     - target: zip
       arch:
         - universal
-  hardenedRuntime: true
-  entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: true
 npmRebuild: false
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -32,6 +32,8 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
+  notarize: false
+  identity: null
 npmRebuild: false
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/


### PR DESCRIPTION
## 概要

macOSリリースをDeveloper ID Application証明書で署名し、Appleへ公証した成果物だけを配布するようにします。

## 変更内容

- macOSジョブの先頭で、証明書とApple ID公証用のGitHub Secretsが揃っていることを検証
- リリース専用のelectron-builder設定でHardened Runtime、アプリ/子プロセス用entitlements、notarizeを有効化
- リリース時のみ署名を必須化し、通常のローカルmacOSビルドは未署名・非公証のまま維持
- ビルド後にcodesign、stapler、Gatekeeperで署名・公証を検証

## 運用前提

以下のGitHub Actions Secretsをリポジトリへ登録する必要があります。

- `CSC_LINK`
- `CSC_KEY_PASSWORD`
- `APPLE_ID`
- `APPLE_APP_SPECIFIC_PASSWORD`
- `APPLE_TEAM_ID`

## 関連 issue

- Closes #167

## 確認事項

- [x] release workflowのYAML構文を検証
- [x] electron-builder 25.1.8の設定schemaを検証
- [x] `npm test`（7 tests）
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Apple Secretsを設定したrelease workflowで署名・公証を実行

Apple Secretsは現在リポジトリに未登録のため、最後の確認は登録後の初回release workflowで実施します。
