### PR TITLE
macOSリリースをDMGでインストール可能にする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,9 @@ jobs:
 
       - name: Get release tag version
         id: tag-version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          RELEASE_TAG="${{ github.event.release.tag_name }}"
           echo "Release tag: $RELEASE_TAG"
 
           # Remove 'release/' prefix if present
@@ -39,10 +40,10 @@ jobs:
           echo "Tag version: $TAG_VERSION"
 
       - name: Verify version consistency
+        env:
+          PACKAGE_VERSION: ${{ steps.get-version.outputs.version }}
+          TAG_VERSION: ${{ steps.tag-version.outputs.tag_version }}
         run: |
-          PACKAGE_VERSION="${{ steps.get-version.outputs.version }}"
-          TAG_VERSION="${{ steps.tag-version.outputs.tag_version }}"
-
           echo "Verifying versions:"
           echo "  package.json: $PACKAGE_VERSION"
           echo "  Release tag:  $TAG_VERSION"
@@ -89,10 +90,11 @@ jobs:
         run: |
           $files = Get-ChildItem -Path dist -Filter *.exe
           foreach ($file in $files) {
-            gh release upload ${{ github.event.release.tag_name }} $file.FullName --clobber
+            gh release upload $env:RELEASE_TAG $file.FullName --clobber
           }
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
 
   build-macos:
     name: Build macOS
@@ -138,8 +140,10 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Verify macOS DMG contents
+        env:
+          RELEASE_VERSION: ${{ needs.check-version.outputs.version }}
         run: |
-          DMG_PATH="dist/tell-${{ needs.check-version.outputs.version }}-universal-mac.dmg"
+          DMG_PATH="dist/tell-${RELEASE_VERSION}-universal-mac.dmg"
           MOUNT_POINT="$(mktemp -d)"
 
           cleanup() {
@@ -154,6 +158,7 @@ jobs:
           APP_PATH="$MOUNT_POINT/tell.app"
           test -d "$APP_PATH"
           test -L "$MOUNT_POINT/Applications"
+          test "$(readlink "$MOUNT_POINT/Applications")" = "/Applications"
 
           ARCHS="$(lipo -archs "$APP_PATH/Contents/MacOS/tell")"
           for arch in x86_64 arm64; do
@@ -173,12 +178,15 @@ jobs:
           name: macos-build
           path: |
             dist/tell-${{ needs.check-version.outputs.version }}-universal-mac.dmg
+          compression-level: 0
           retention-days: 7
 
       - name: Upload to release
         run: >-
-          gh release upload ${{ github.event.release.tag_name }}
-          "dist/tell-${{ needs.check-version.outputs.version }}-universal-mac.dmg"
+          gh release upload "$RELEASE_TAG"
+          "dist/tell-${RELEASE_VERSION}-universal-mac.dmg"
           --clobber
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_VERSION: ${{ needs.check-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,9 +137,32 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-      - name: Verify macOS signature and notarization
+      - name: Verify macOS DMG contents
         run: |
-          APP_PATH="dist/mac-universal/tell.app"
+          DMG_PATH="dist/tell-${{ needs.check-version.outputs.version }}-universal-mac.dmg"
+          MOUNT_POINT="$(mktemp -d)"
+
+          cleanup() {
+            hdiutil detach "$MOUNT_POINT" || true
+            rmdir "$MOUNT_POINT" || true
+          }
+          trap cleanup EXIT
+
+          test -f "$DMG_PATH"
+          hdiutil attach "$DMG_PATH" -readonly -nobrowse -mountpoint "$MOUNT_POINT"
+
+          APP_PATH="$MOUNT_POINT/tell.app"
+          test -d "$APP_PATH"
+          test -L "$MOUNT_POINT/Applications"
+
+          ARCHS="$(lipo -archs "$APP_PATH/Contents/MacOS/tell")"
+          for arch in x86_64 arm64; do
+            if [[ " $ARCHS " != *" $arch "* ]]; then
+              echo "::error::Missing $arch architecture: $ARCHS"
+              exit 1
+            fi
+          done
+
           codesign --verify --deep --strict --verbose=2 "$APP_PATH"
           xcrun stapler validate "$APP_PATH"
           spctl --assess --verbose --type exec "$APP_PATH"
@@ -149,15 +172,13 @@ jobs:
         with:
           name: macos-build
           path: |
-            dist/*.zip
+            dist/tell-${{ needs.check-version.outputs.version }}-universal-mac.dmg
           retention-days: 7
 
       - name: Upload to release
-        run: |
-          for file in dist/*.zip; do
-            if [ -f "$file" ]; then
-              gh release upload ${{ github.event.release.tag_name }} "$file" --clobber
-            fi
-          done
+        run: >-
+          gh release upload ${{ github.event.release.tag_name }}
+          "dist/tell-${{ needs.check-version.outputs.version }}-universal-mac.dmg"
+          --clobber
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,9 +175,8 @@ $ npm run db:studio
 
 4. **Automated Build**
    - GitHub Actions will automatically start and generate binaries:
-     - Windows: `tell-{version}-setup.exe` (x64)
-     - macOS: `tell-{version}.dmg` (Universal: Intel & Apple Silicon)
-     - Linux: AppImage, snap, deb formats
+     - Windows: `tell-{version}-win.exe` (x64)
+     - macOS: `tell-{version}-universal-mac.dmg` (Universal: Intel & Apple Silicon)
    - Generated binaries will be automatically uploaded to the release page
 
 ### Version Management

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ tell is a desktop application that helps you stay on top of your GitHub activiti
    - **Windows**: Run `dist/tell-{version}-win.exe`
    - **macOS**: Open `dist/mac-universal/tell.app`
 
+### Install a macOS release
+
+1. Download `tell-{version}-universal-mac.dmg` from the GitHub Release.
+2. Open the DMG.
+3. Drag `tell.app` to the `Applications` folder shown in the DMG window.
+4. Launch tell from the Applications folder.
+
 ## 🚀 Getting Started
 
 ### Initial Setup

--- a/docs/plans/done/20260809-release-macos-dmg.md
+++ b/docs/plans/done/20260809-release-macos-dmg.md
@@ -1,0 +1,76 @@
+# macOSリリースをインストール可能なDMGで配布する
+
+- 作成日: 2026-08-09
+- ステータス: ドラフト
+
+## 概要
+
+GitHub Releaseで配布するmacOS向け成果物をZIPからUniversal DMGへ変更する。DMGを開くと`tell.app`と`Applications`フォルダへのリンクが表示され、ユーザーがアプリをApplicationsへドラッグしてインストールできるようにする。署名・Apple公証の検証対象をビルド途中のappだけでなく、実際に配布するDMG内のappまで拡張する。
+
+## 背景・前提（コンテキスト）
+
+- tellはElectron、React、TypeScriptで構成され、`electron-builder` 25.1.8でWindows/macOS成果物を生成している。
+- 通常のmacOSビルドは`electron-builder.yml`、リリース時の署名・公証設定は`electron-builder.release.yml`に分離されている。共通設定は実装時に両設定から参照できる基底ファイルへ分離する。
+- 現在のmacOS targetはUniversal ZIPで、Release workflowは`dist/*.zip`をGitHub Actions artifactとGitHub Releaseへアップロードしている。
+- `v0.1.0`では`tell-0.1.0-universal-mac.zip`の生成、Developer ID Application署名、Apple公証、staple、Gatekeeper判定には成功した。一方、CIの検証対象はZIP生成元の`dist/mac-universal/tell.app`であり、ユーザーが取得する配布ファイルを開いて中身を検証する工程はない。
+- READMEはローカルビルド後のappを直接開く手順を案内し、CONTRIBUTINGはリリース成果物としてUniversal DMGを記載している。実装とリリース文書の想定が一致していない。
+- `build/`にはアプリアイコンとentitlementsがあり、DMG専用の背景画像はない。electron-builderにはDMG生成に必要な`dmg-builder`が既にlockfile経由で含まれている。
+- アプリ内に`electron-updater`の利用実装はなく、Squirrel.Mac向けZIPを同時生成する要件は現時点でない。
+- `docs/CONTEXT.md`と`docs/PLAN.md`は存在しないため、README、CONTRIBUTING、ビルド設定、Release workflow、既存プランから文脈を補い、標準書式を使用する。
+
+## 要件
+
+- GitHub ReleaseのmacOS向け配布ファイルをUniversal ZIPからUniversal DMGへ置き換える。
+- DMG内に`tell.app`と`Applications`フォルダへのリンクを配置し、ドラッグ＆ドロップでインストールできるようにする。
+- DMG内の`tell.app`はIntel（x64）とApple Silicon（arm64）の両方を含むUniversal binaryとする。
+- リリース専用設定でDeveloper ID Application署名、Hardened Runtime、entitlements、Apple公証、stapleを維持する。
+- GitHub Releaseへアップロードする前に、生成したDMGをマウントし、DMG内のアプリについてアーキテクチャ、コード署名、公証チケット、Gatekeeper受理を検証する。
+- GitHub Actions artifactとGitHub ReleaseにはDMGだけをmacOS成果物としてアップロードする。
+- DMGのファイル名はバージョンとUniversal版であることが分かる`tell-${version}-universal-mac.dmg`とする。
+- 通常のローカル`npm run build:mac`は現状の未署名・非公証ZIPビルドを維持し、リリース時だけDMGを生成する。
+- 関連するREADME/CONTRIBUTINGの成果物名とインストール手順を実装に合わせる。
+- スコープ外: Mac App Store配布、PKGインストーラー、自動更新の導入、DMGの独自背景デザイン、Windows配布形式の変更、既存`v0.1.0`リリースの成果物差し替え。
+
+## 確定した論点
+
+- **DMGのみを配布する**: アプリ内に自動更新処理がなく、electron-builderがSquirrel.Mac向けに要求するZIPを維持する必要がないため、リリースのmacOS成果物はDMGへ置き換える。
+- **リリース設定だけtargetを上書きする**: 要件はリリース配布形式の変更であり、通常のローカルビルドへ署名・公証やDMG作成コストを持ち込まない。`electron-builder.release.yml`の`mac.target`でUniversal DMGを指定する。
+- **標準的なドラッグ＆ドロップUIを使う**: DMG専用の背景アセットは追加せず、`contents`で`tell.app`と`/Applications`へのlinkを明示配置する。独自デザインなしでもインストール方法が伝わる最小構成とする。
+- **DMG自体は署名しない**: electron-builderのDMG設定ではDMG署名は不要で、公証との組み合わせで不要なエラーを招く旨が示されている。DMG内のappをDeveloper IDで署名・公証する既存方式を維持する。
+- **配布物を展開・マウント後に検証する**: ビルドディレクトリのapp検証だけでは、パッケージングやアップロード対象の誤りを検出できない。`hdiutil attach`で実際のDMGを読み取り専用マウントし、その中のappを検証してからアップロードする。
+- **Info.plistの追加情報を正しいmap形式にする**: 現在の`mac.extendInfo`は配列で、生成されたInfo.plistに`0`〜`3`の辞書として使用目的文言が入る。DMGからコピーしたappがLaunch Servicesで正しく扱われる前提を固めるため、各`NS*UsageDescription`を`extendInfo`直下のキーへ修正する。
+
+## 実装方針
+
+共通のパッケージ設定を基底ファイルへ分離し、`electron-builder.yml`は通常ビルド用のUniversal ZIP targetと未署名設定、`electron-builder.release.yml`はUniversal DMG targetと署名・公証設定をそれぞれ定義する。electron-builderは継承元と子のtarget配列を結合するため、通常設定を直接継承してtargetだけを置換する構成は採用しない。リリース設定のトップレベル`dmg`には、成果物名、ウィンドウサイズ、アプリアイコンとApplicationsリンクの位置を定義する。
+
+Release workflowではDMGのパスを単一の変数として扱う。ビルド完了後、`hdiutil attach -readonly -nobrowse`でDMGを一時マウントし、マウント内の`tell.app`を対象に`lipo`、`codesign`、`stapler`、`spctl`を実行する。成功・失敗にかかわらず確実にdetachするようshellのtrapを使う。すべての検証に成功したDMGだけをActions artifactとGitHub Releaseへアップロードする。
+
+## 実装ステップ
+
+1. 共通のelectron-builder設定を`electron-builder.base.yml`へ分離し、`mac.extendInfo`を配列からmapへ修正する。カメラ、マイク、Documents、Downloadsの使用目的文言がInfo.plistの正しいトップレベルキーとして出力されるようにする。
+2. `electron-builder.yml`と`electron-builder.release.yml`から共通設定を継承する。通常設定はUniversal ZIP、`identity: null`、`notarize: false`を維持し、リリース設定は`dmg`・`universal` targetと既存の署名・公証設定を定義する。
+3. 同リリース設定へ`dmg`セクションを追加し、`artifactName: tell-${version}-universal-mac.${ext}`、DMGタイトル、ウィンドウサイズ、アプリアイコンと`/Applications`リンクの座標を定義する。DMG署名は無効のままとする。
+4. `.github/workflows/release.yml`のmacOS検証を、生成された`dist/tell-<version>-universal-mac.dmg`をマウントして検証する処理へ変更する。DMGの存在と一意性を確認し、`lipo -archs`でx86_64/arm64、`codesign --verify --deep --strict`で署名、`xcrun stapler validate`で公証チケット、`spctl --assess --type exec`でGatekeeper受理を検証する。
+5. DMGマウント処理に一時マウントポイントと`trap`によるdetach/後始末を設け、検証失敗時にもrunnerへマウント状態を残さない。DMG内に`tell.app`とApplicationsリンクが存在することも検査する。
+6. macOSのActions artifactとGitHub Release upload対象を`dist/*.zip`から検証済みの単一DMGへ変更し、ZIPやblockmapなど想定外のファイルをアップロードしない。
+7. READMEにDMGを開いて`tell.app`をApplicationsへドラッグするインストール手順を追加し、CONTRIBUTINGの自動生成成果物を現行workflow（Windows portable EXE、macOS Universal DMG）と実際のファイル名に合わせる。
+8. electron-builder 25.1.8の設定schemaで通常/リリース両設定を検証し、通常設定がZIP・未署名・非公証、リリース設定がDMG・Universal・署名必須・公証有効になる実効設定を確認する。`plutil`で生成Info.plistの使用目的キーも確認する。
+9. `npm test`、`npm run lint`、`npm run typecheck`、`npm run build`を実行し、アプリコードに回帰がないことを確認する。資格情報なしのローカル環境では通常の`npm run build:mac`が引き続き成功することを確認する。
+10. GitHub Secretsを設定したrelease workflowで検証用リリースを実行し、DMG生成、DMG内appのUniversal構成、署名、公証、staple、Gatekeeper、artifact/release uploadがすべて成功することを確認する。別のmacOS環境でDMGをダウンロードし、マウント、Applicationsへのコピー、初回起動まで手動確認する。
+
+## 影響範囲・リスク
+
+- 影響を受けるファイル: `electron-builder.base.yml`、`electron-builder.yml`、`electron-builder.release.yml`、`.github/workflows/release.yml`、`README.md`、`CONTRIBUTING.md`。
+- 依存関係: 新規npm依存は不要。既存のelectron-builder/dmg-builderとmacOS標準の`hdiutil`、`lipo`、`codesign`、`xcrun stapler`、`spctl`を利用する。
+- リスク: electron-builderの継承設定でbaseのZIP targetが残り、DMGとZIPの両方が生成される可能性がある。実効設定とdist内成果物を検査し、uploadを単一の期待DMGへ限定する。
+- リスク: DMGのapp名、volume名、マウントパスに空白や動的値が入るとshell処理が壊れる可能性がある。パスを常にquoteし、`hdiutil -plist`または明示した一時マウントポイントで対象を決定する。
+- リスク: 検証途中で失敗するとDMGがマウントされたままになる。trapでdetachを保証する。
+- リスク: DMGウィンドウの座標によってアプリとApplicationsリンクが重なり、インストール方法が分かりにくくなる。標準サイズで左右に分け、実際にFinderで開いて確認する。
+- リスク: `mac.extendInfo`の構造修正は生成Info.plistを変える。意図した4つの使用目的キー以外に差分がないことを生成物で確認する。
+- リスク: 配布形式をZIPからDMGへ変更すると、ZIPを直接参照している外部利用者やスクリプトは影響を受ける。`v0.1.0`は変更せず、次バージョンのリリースノートで配布形式変更を明記する。
+- リスク: DMG内のアプリを検証しても、ユーザー環境固有のGatekeeper・権限問題は完全には再現できない。CI検証に加えて別macOS環境でのダウンロードから初回起動までを受け入れ確認に含める。
+
+## 未確定事項
+
+- なし。DMGの独自背景やブランドデザインが必要になった場合は、インストール機能とは分離して後続対応とする。

--- a/electron-builder.base.yml
+++ b/electron-builder.base.yml
@@ -1,0 +1,33 @@
+appId: net.noncore.tell
+productName: tell
+directories:
+  buildResources: build
+files:
+  - '!**/.vscode/*'
+  - '!src/*'
+  - '!electron.vite.config.{js,ts,mjs,cjs}'
+  - '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
+  - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
+  - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
+asarUnpack:
+  - resources/**
+win:
+  icon: build/icon.ico
+  executableName: tell
+  target:
+    - target: portable
+      arch:
+        - x64
+portable:
+  artifactName: ${name}-${version}-win.${ext}
+mac:
+  icon: build/icon.png
+  entitlementsInherit: build/entitlements.mac.plist
+  extendInfo:
+    NSCameraUsageDescription: Application requests access to the device's camera.
+    NSMicrophoneUsageDescription: Application requests access to the device's microphone.
+    NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
+    NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
+npmRebuild: false
+electronDownload:
+  mirror: https://npmmirror.com/mirrors/electron/

--- a/electron-builder.release.yml
+++ b/electron-builder.release.yml
@@ -1,8 +1,26 @@
-extends: electron-builder.yml
+extends: electron-builder.base.yml
 mac:
+  target:
+    - target: dmg
+      arch:
+        - universal
   forceCodeSigning: true
   identity: ''
   hardenedRuntime: true
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
   notarize: true
+dmg:
+  artifactName: ${name}-${version}-universal-mac.${ext}
+  title: ${productName} ${version}
+  sign: false
+  window:
+    width: 540
+    height: 380
+  contents:
+    - x: 140
+      y: 190
+    - x: 400
+      y: 190
+      type: link
+      path: /Applications

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,39 +1,8 @@
-appId: net.noncore.tell
-productName: tell
-directories:
-  buildResources: build
-files:
-  - '!**/.vscode/*'
-  - '!src/*'
-  - '!electron.vite.config.{js,ts,mjs,cjs}'
-  - '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
-  - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
-  - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
-asarUnpack:
-  - resources/**
-win:
-  icon: build/icon.ico
-  executableName: tell
-  target:
-    - target: portable
-      arch:
-        - x64
-portable:
-  artifactName: ${name}-${version}-win.${ext}
+extends: electron-builder.base.yml
 mac:
-  icon: build/icon.png
   target:
     - target: zip
       arch:
         - universal
-  entitlementsInherit: build/entitlements.mac.plist
-  extendInfo:
-    - NSCameraUsageDescription: Application requests access to the device's camera.
-    - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
-    - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
-    - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: false
   identity: null
-npmRebuild: false
-electronDownload:
-  mirror: https://npmmirror.com/mirrors/electron/


### PR DESCRIPTION
## 概要

macOSリリースの配布形式をZIPからUniversal DMGへ変更し、アプリをApplicationsへドラッグしてインストールできるようにします。実際に配布するDMGをマウントし、中のアプリを検証してからアップロードします。

## 変更内容

- electron-builderの共通設定を基底ファイルへ分離し、通常ビルドはZIP、リリースビルドはDMGのみを生成
- DMGへ`tell.app`とApplicationsリンクを配置し、成果物名を統一
- Release workflowでDMGをマウントし、Universal構成、署名、公証チケット、Gatekeeper受理を検証
- 検証済みDMGだけをActions artifactとGitHub Releaseへアップロード
- `mac.extendInfo`を正しいmap形式に修正
- READMEとCONTRIBUTINGの配布物・インストール手順を更新

## 関連 issue

- Closes #177

## 確認事項

- [x] electron-builder設定schemaと継承後の実効設定を検証
- [x] `npm test`（7 tests）
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Apple資格情報なしの通常`npm run build:mac`でUniversal ZIP生成を確認
- [x] 署名設定をローカル検証用に無効化してUniversal DMGを生成・マウントし、appとApplicationsリンクを確認
- [ ] GitHub Secretsを使用したrelease workflowで、DMG内アプリの署名・公証・Gatekeeper検証を確認
